### PR TITLE
[#6] Add initial README for Compliment Mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# Compliment-Mirror
+# Compliment Mirror
+
+A simple web app that shows you a random compliment when you open it.
+
+## Overview
+
+Compliment Mirror is a lightweight, feel-good web application. Each visit surfaces a random compliment to brighten your day. The product roadmap includes:
+
+- **Personalized compliments** — compliments tailored to you that refresh daily
+- **Anonymous compliment sharing** — send a compliment to a friend via a shareable link, creating a lightweight organic sharing loop
+
+## Getting Started
+
+> This repository is in early development. Setup instructions will be added as the project grows.
+
+## Project Status
+
+This repository is intentionally minimal and serves as an early test project for [Orchestra](https://github.com/hilalfnisanci) runtime workflows.
+
+## Contributing
+
+Contributions, ideas, and feedback are welcome. Open an issue to start a conversation.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- Replaces the placeholder `# Compliment-Mirror` stub with a complete initial README
- Covers project overview, planned features (personalized compliments, anonymous sharing), project status, contributing, and license

## Changes

- `README.md` — expanded from a single heading to a full project README

Closes #6