### PR TITLE
[#8] Add initial .gitignore for Compliment Mirror

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Dependencies
+node_modules/
+bower_components/
+
+# Build artifacts
+dist/
+build/
+out/
+.next/
+.nuxt/
+.vite/
+.parcel-cache/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor directories and files
+.idea/
+.vscode/
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?


### PR DESCRIPTION
## Summary

- Adds an initial `.gitignore` suitable for a simple frontend/web repository

## Changes

- `.gitignore` — covers the following categories:
  - **Dependencies**: `node_modules/`, `bower_components/`
  - **Build artifacts**: `dist/`, `build/`, common framework output dirs (`.next/`, `.nuxt/`, `.vite/`, `.parcel-cache/`)
  - **Environment files**: `.env`, `.env.local`, `.env.*.local`
  - **Logs**: `*.log`, npm/yarn debug logs
  - **OS files**: `.DS_Store`, `Thumbs.db`
  - **Editor directories**: `.idea/`, `.vscode/`, and related IDE files

Closes #8

## Test plan

- [x] `.gitignore` is present on the branch
- [x] All listed patterns cover common frontend/web development unnecessary files

🤖 Generated with [Claude Code](https://claude.com/claude-code)