### PR TITLE
[#11] Add initial .gitignore for Compliment Mirror

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Dependencies
+node_modules/
+bower_components/
+
+# Build output
+dist/
+build/
+out/
+.cache/
+.parcel-cache/
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS files
+.DS_Store
+Thumbs.db
+Desktop.ini
+
+# Editor/IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Package manager locks (keep one, ignore others)
+# Uncomment the one you don't use:
+# package-lock.json
+# yarn.lock


### PR DESCRIPTION
## Summary

- Adds a `.gitignore` suitable for a simple frontend/web project
- Covers `node_modules/`, build output (`dist/`, `build/`, `.cache/`), environment files (`.env*`), logs, OS files (`.DS_Store`, `Thumbs.db`), and common editor/IDE directories

Closes #11

## Test plan

- [ ] Verify `.gitignore` is present in the repository root
- [ ] Confirm OS/editor artifacts are ignored by git in local testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)