### PR TITLE
[#15] Add initial landing page for Compliment Mirror

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Compliment Mirror</title>
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: Georgia, 'Times New Roman', serif;
+      background-color: #faf9f6;
+      color: #2c2c2c;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .container {
+      text-align: center;
+      max-width: 560px;
+      padding: 2rem;
+    }
+
+    h1 {
+      font-size: 2.4rem;
+      font-weight: normal;
+      letter-spacing: 0.02em;
+      margin-bottom: 0.5rem;
+    }
+
+    .subtitle {
+      font-size: 1rem;
+      color: #777;
+      margin-bottom: 2.5rem;
+    }
+
+    .compliment-box {
+      background: #fff;
+      border: 1px solid #e0ddd8;
+      border-radius: 12px;
+      padding: 2rem 2.5rem;
+      min-height: 100px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-bottom: 2rem;
+    }
+
+    .compliment-text {
+      font-size: 1.25rem;
+      font-style: italic;
+      color: #555;
+    }
+
+    .btn {
+      background-color: #2c2c2c;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      padding: 0.75rem 2rem;
+      font-size: 1rem;
+      font-family: inherit;
+      cursor: pointer;
+      transition: background-color 0.2s ease;
+    }
+
+    .btn:hover {
+      background-color: #444;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Compliment Mirror</h1>
+    <p class="subtitle">A kind word, just for you.</p>
+
+    <div class="compliment-box">
+      <p class="compliment-text" id="compliment">Your compliment will appear here.</p>
+    </div>
+
+    <button class="btn" id="new-compliment-btn" type="button">New Compliment</button>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Creates `index.html` as the starting point for the Compliment Mirror web app
- Includes app title ("Compliment Mirror") and short tagline
- Displays a dedicated compliment area (`#compliment`) ready to be populated later
- Adds a "New Compliment" placeholder button (`#new-compliment-btn`) for future interaction
- Minimal inline CSS — clean layout, easy to extend

## No logic added
The page is fully static. The button and compliment element are wired up with IDs for future JS hookup only.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)