### PR TITLE
[#19] Add shareable compliment cards

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,103 @@
+// Do not reorder or delete entries — this breaks existing shared links.
+const COMPLIMENTS = [
+  "You make the people around you feel seen.",
+  "Your curiosity is genuinely contagious.",
+  "You handle hard things with real grace.",
+  "The world is a little warmer because you're in it.",
+  "You notice things most people miss.",
+  "Your kindness lands — people remember it.",
+  "You bring calm into rooms that need it.",
+  "The way you listen is a gift.",
+  "You have a talent for making hard things feel possible.",
+  "You show up, and that matters more than you know.",
+  "Your honesty is rare and genuinely appreciated.",
+  "You have excellent instincts.",
+  "You make ordinary moments feel worth paying attention to.",
+  "You are more capable than you give yourself credit for.",
+  "Your perspective adds something no one else can.",
+  "You are someone people feel safe around.",
+  "You ask the right questions.",
+  "The effort you put in doesn't go unnoticed.",
+  "You carry yourself with a quiet confidence that's inspiring.",
+  "You are exactly the kind of person this world needs more of.",
+  "Your creativity is one of your best features.",
+  "You have a way of making complicated things feel simple.",
+  "People feel better after talking to you.",
+  "You are thoughtful in a way that is genuinely rare.",
+  "You deserve every good thing coming your way."
+];
+
+let currentIndex = null;
+
+window.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  if (params.has('c')) {
+    renderSharedView(params);
+  } else {
+    renderInteractiveView();
+  }
+});
+
+function renderInteractiveView() {
+  pickRandom();
+  document.getElementById('new-compliment-btn').addEventListener('click', pickRandom);
+  document.getElementById('share-btn').addEventListener('click', handleShare);
+}
+
+function pickRandom() {
+  const next = Math.floor(Math.random() * COMPLIMENTS.length);
+  currentIndex = next;
+  document.getElementById('compliment').textContent = COMPLIMENTS[currentIndex];
+}
+
+function handleShare() {
+  const name = document.getElementById('recipient-name').value.trim();
+  const params = new URLSearchParams({ c: currentIndex });
+  if (name) params.set('to', name);
+
+  const url = `${location.origin}${location.pathname}?${params}`;
+
+  navigator.clipboard.writeText(url).then(() => {
+    showFeedback('Link copied to clipboard!');
+  }).catch(() => {
+    showFeedback(`Share this link: ${url}`);
+  });
+}
+
+function showFeedback(message) {
+  const el = document.getElementById('share-feedback');
+  el.textContent = message;
+  setTimeout(() => { el.textContent = ''; }, 4000);
+}
+
+function renderSharedView(params) {
+  const index = parseInt(params.get('c'), 10);
+  const name = params.get('to') || null;
+
+  if (isNaN(index) || index < 0 || index >= COMPLIMENTS.length) {
+    document.getElementById('compliment').textContent =
+      "This link doesn't seem right — try generating a new compliment.";
+    hideInteractiveControls();
+    return;
+  }
+
+  document.getElementById('compliment').textContent = COMPLIMENTS[index];
+
+  if (name) {
+    const header = document.createElement('p');
+    header.className = 'shared-header';
+    header.textContent = `This compliment was made for ${name}`;
+    document.querySelector('.compliment-box').prepend(header);
+  }
+
+  hideInteractiveControls();
+  document.body.classList.add('shared-view');
+}
+
+function hideInteractiveControls() {
+  ['new-compliment-btn', 'recipient-name', 'share-btn', 'share-feedback']
+    .forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.style.display = 'none';
+    });
+}

--- a/app.js
+++ b/app.js
@@ -55,7 +55,9 @@ function handleShare() {
   const params = new URLSearchParams({ c: currentIndex });
   if (name) params.set('to', name);
 
-  const url = `${location.origin}${location.pathname}?${params}`;
+  // location.origin returns "null" for file:// (opaque origins); split href instead
+  const base = location.href.split('?')[0];
+  const url = `${base}?${params}`;
 
   navigator.clipboard.writeText(url).then(() => {
     showFeedback('Link copied to clipboard!');

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Compliment Mirror</title>
   <link rel="stylesheet" href="styles.css" />
+  <script src="app.js" defer></script>
 </head>
 <body>
   <div class="container">
@@ -16,6 +17,15 @@
     </div>
 
     <button class="btn" id="new-compliment-btn" type="button">New Compliment</button>
+    <input
+      type="text"
+      id="recipient-name"
+      placeholder="Add a name (optional)"
+      maxlength="60"
+      autocomplete="off"
+    />
+    <button class="btn btn-secondary" id="share-btn" type="button">Share this compliment</button>
+    <p class="share-feedback" id="share-feedback" aria-live="polite"></p>
   </div>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -61,8 +61,56 @@ h1 {
   font-family: inherit;
   cursor: pointer;
   transition: background-color 0.2s ease;
+  margin-top: 16px;
 }
 
 .btn:hover {
   background-color: #444;
+}
+
+#recipient-name {
+  width: 100%;
+  padding: 10px 14px;
+  margin-top: 12px;
+  font-family: Georgia, serif;
+  font-size: 1rem;
+  color: #2c2c2c;
+  background: #fff;
+  border: 1px solid #e0ddd8;
+  border-radius: 8px;
+  outline: none;
+  box-sizing: border-box;
+}
+
+#recipient-name:focus {
+  border-color: #aaa;
+}
+
+.btn-secondary {
+  background: transparent;
+  color: #2c2c2c;
+  border: 1px solid #2c2c2c;
+  margin-top: 10px;
+}
+
+.btn-secondary:hover {
+  background: #f0ede8;
+}
+
+.share-feedback {
+  font-size: 0.875rem;
+  color: #555;
+  margin-top: 8px;
+  min-height: 1.4em;
+}
+
+.shared-view .container {
+  padding: 60px 24px;
+}
+
+.shared-header {
+  font-size: 0.875rem;
+  color: #777;
+  margin-bottom: 12px;
+  font-style: normal;
 }

--- a/styles.css
+++ b/styles.css
@@ -40,6 +40,7 @@ h1 {
   padding: 2rem 2.5rem;
   min-height: 100px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   margin-bottom: 2rem;


### PR DESCRIPTION
Closes #19

## Summary

- Creates `app.js` with 25 compliments, random selection on load, "New Compliment" button, share link generation (clipboard API with text fallback), and shared view rendering from URL params (`?c=<index>&to=<name>`)
- Updates `index.html` with recipient name input, share button, share feedback label, and `<script src="app.js" defer>`
- Adds CSS to `styles.css` for the input, secondary outlined button, feedback text, and shared-view layout overrides

## How it works

- **Interactive view** (no URL params): shows a random compliment, lets user regenerate, enter a recipient name, and click "Share this compliment" to copy a link
- **Shared view** (`?c=N` or `?c=N&to=Name`): renders the specific compliment statically, shows an optional "made for [name]" header, hides all interactive controls
- **Error handling**: invalid/out-of-range `c` param shows a graceful error message instead of crashing
- Works on `file://` protocol; clipboard API falls back to displaying the URL as text when unavailable

## Test plan

- [ ] Open `index.html` directly — compliment appears on load
- [ ] Click "New Compliment" — different compliment appears
- [ ] Enter a name and click "Share" — URL with `?to=Name&c=N` copied to clipboard (or shown as fallback)
- [ ] Open `?to=Alice&c=3` — correct compliment shown, "made for Alice" header visible, interactive controls hidden
- [ ] Open `?c=5` (no name) — correct compliment, no "made for" header
- [ ] Open `?c=9999` — graceful error message shown
- [ ] Open `?to=Alice` (no `c`) — falls through to interactive view

🤖 Generated with [Claude Code](https://claude.com/claude-code)