### PR TITLE
[#23] Add dark mode toggle with CSS variables

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,7 @@ const COMPLIMENTS = [
 let currentIndex = null;
 
 window.addEventListener('DOMContentLoaded', () => {
+  initTheme();
   const params = new URLSearchParams(window.location.search);
   if (params.has('c')) {
     renderSharedView(params);
@@ -37,6 +38,15 @@ window.addEventListener('DOMContentLoaded', () => {
     renderInteractiveView();
   }
 });
+
+function initTheme() {
+  document.getElementById('theme-toggle').addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme');
+    const next = current === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+  });
+}
 
 function renderInteractiveView() {
   pickRandom();

--- a/app.js
+++ b/app.js
@@ -30,7 +30,7 @@ const COMPLIMENTS = [
 let currentIndex = null;
 
 window.addEventListener('DOMContentLoaded', () => {
-  initTheme();
+  attachThemeToggle();
   const params = new URLSearchParams(window.location.search);
   if (params.has('c')) {
     renderSharedView(params);
@@ -39,12 +39,17 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 });
 
-function initTheme() {
-  document.getElementById('theme-toggle').addEventListener('click', () => {
+function attachThemeToggle() {
+  const btn = document.getElementById('theme-toggle');
+  const initial = document.documentElement.getAttribute('data-theme');
+  btn.setAttribute('aria-label', initial === 'dark' ? 'Toggle light mode' : 'Toggle dark mode');
+
+  btn.addEventListener('click', () => {
     const current = document.documentElement.getAttribute('data-theme');
     const next = current === 'dark' ? 'light' : 'dark';
     document.documentElement.setAttribute('data-theme', next);
     localStorage.setItem('theme', next);
+    btn.setAttribute('aria-label', next === 'dark' ? 'Toggle light mode' : 'Toggle dark mode');
   });
 }
 

--- a/index.html
+++ b/index.html
@@ -5,9 +5,35 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Compliment Mirror</title>
   <link rel="stylesheet" href="styles.css" />
+  <script>
+    (function () {
+      var saved = localStorage.getItem('theme');
+      if (saved) {
+        document.documentElement.setAttribute('data-theme', saved);
+      } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      }
+    })();
+  </script>
   <script src="app.js" defer></script>
 </head>
 <body>
+  <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle dark mode">
+    <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="5"/>
+      <line x1="12" y1="1" x2="12" y2="3"/>
+      <line x1="12" y1="21" x2="12" y2="23"/>
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+      <line x1="1" y1="12" x2="3" y2="12"/>
+      <line x1="21" y1="12" x2="23" y2="12"/>
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+    </svg>
+    <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+    </svg>
+  </button>
   <div class="container">
     <h1>Compliment Mirror</h1>
     <p class="subtitle">A kind word, just for you.</p>

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,35 @@
+:root {
+  --bg-body: #faf9f6;
+  --color-text: #2c2c2c;
+  --color-subtle: #777;
+  --bg-card: #fff;
+  --border-color: #e0ddd8;
+  --color-muted: #555;
+  --bg-btn: #2c2c2c;
+  --color-btn-text: #fff;
+  --bg-btn-hover: #444;
+  --color-input: #2c2c2c;
+  --bg-input: #fff;
+  --border-focus: #aaa;
+  --bg-secondary-hover: #f0ede8;
+}
+
+[data-theme="dark"] {
+  --bg-body: #1a1a1a;
+  --color-text: #e8e6e3;
+  --color-subtle: #999;
+  --bg-card: #2a2a2a;
+  --border-color: #444;
+  --color-muted: #c0bdb8;
+  --bg-btn: #e8e6e3;
+  --color-btn-text: #1a1a1a;
+  --bg-btn-hover: #ccc;
+  --color-input: #e8e6e3;
+  --bg-input: #2a2a2a;
+  --border-focus: #777;
+  --bg-secondary-hover: #383838;
+}
+
 *, *::before, *::after {
   box-sizing: border-box;
   margin: 0;
@@ -6,12 +38,13 @@
 
 body {
   font-family: Georgia, 'Times New Roman', serif;
-  background-color: #faf9f6;
-  color: #2c2c2c;
+  background-color: var(--bg-body);
+  color: var(--color-text);
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .container {
@@ -29,13 +62,14 @@ h1 {
 
 .subtitle {
   font-size: 1rem;
-  color: #777;
+  color: var(--color-subtle);
   margin-bottom: 2.5rem;
+  transition: color 0.3s ease;
 }
 
 .compliment-box {
-  background: #fff;
-  border: 1px solid #e0ddd8;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 2rem 2.5rem;
   min-height: 100px;
@@ -44,29 +78,31 @@ h1 {
   align-items: center;
   justify-content: center;
   margin-bottom: 2rem;
+  transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
 .compliment-text {
   font-size: 1.25rem;
   font-style: italic;
-  color: #555;
+  color: var(--color-muted);
+  transition: color 0.3s ease;
 }
 
 .btn {
-  background-color: #2c2c2c;
-  color: #fff;
+  background-color: var(--bg-btn);
+  color: var(--color-btn-text);
   border: none;
   border-radius: 8px;
   padding: 0.75rem 2rem;
   font-size: 1rem;
   font-family: inherit;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: background-color 0.2s ease, color 0.3s ease;
   margin-top: 16px;
 }
 
 .btn:hover {
-  background-color: #444;
+  background-color: var(--bg-btn-hover);
 }
 
 #recipient-name {
@@ -75,34 +111,37 @@ h1 {
   margin-top: 12px;
   font-family: Georgia, serif;
   font-size: 1rem;
-  color: #2c2c2c;
-  background: #fff;
-  border: 1px solid #e0ddd8;
+  color: var(--color-input);
+  background: var(--bg-input);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   outline: none;
   box-sizing: border-box;
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }
 
 #recipient-name:focus {
-  border-color: #aaa;
+  border-color: var(--border-focus);
 }
 
 .btn-secondary {
   background: transparent;
-  color: #2c2c2c;
-  border: 1px solid #2c2c2c;
+  color: var(--color-text);
+  border: 1px solid var(--border-color);
   margin-top: 10px;
+  transition: background-color 0.2s ease, color 0.3s ease, border-color 0.3s ease;
 }
 
 .btn-secondary:hover {
-  background: #f0ede8;
+  background: var(--bg-secondary-hover);
 }
 
 .share-feedback {
   font-size: 0.875rem;
-  color: #555;
+  color: var(--color-muted);
   margin-top: 8px;
   min-height: 1.4em;
+  transition: color 0.3s ease;
 }
 
 .shared-view .container {
@@ -111,7 +150,45 @@ h1 {
 
 .shared-header {
   font-size: 0.875rem;
-  color: #777;
+  color: var(--color-subtle);
   margin-bottom: 12px;
   font-style: normal;
+  transition: color 0.3s ease;
+}
+
+.theme-toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
+  width: 2.5rem;
+  height: 2.5rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text);
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+.theme-toggle:hover {
+  background-color: var(--bg-secondary-hover);
+}
+
+.icon-sun {
+  display: none;
+}
+
+.icon-moon {
+  display: block;
+}
+
+[data-theme="dark"] .icon-sun {
+  display: block;
+}
+
+[data-theme="dark"] .icon-moon {
+  display: none;
 }

--- a/styles.css
+++ b/styles.css
@@ -127,7 +127,7 @@ h1 {
 .btn-secondary {
   background: transparent;
   color: var(--color-text);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--color-text);
   margin-top: 10px;
   transition: background-color 0.2s ease, color 0.3s ease, border-color 0.3s ease;
 }


### PR DESCRIPTION
## Summary

- Refactored `styles.css` to use CSS custom properties (`--bg-body`, `--color-text`, `--border-color`, etc.) for all colors, with `:root` defining light mode defaults and `[data-theme="dark"]` overrides
- Added a fixed sun/moon toggle button in the top-right corner that swaps icons based on the active theme
- Persists the user's choice in `localStorage` and restores it on page load via an inline `<head>` script (prevents flash of wrong theme)
- Defaults to the system `prefers-color-scheme` when no saved preference exists
- All color-bearing elements transition smoothly at `0.3s ease`

## Test plan

- [ ] Open the page — should match system dark/light preference on first load
- [ ] Click the toggle — should switch theme and show the opposite icon
- [ ] Reload the page — should restore the saved theme from localStorage
- [ ] Clear localStorage and reload — should fall back to system preference
- [ ] All existing features (new compliment, name input, share link) work in both modes
- [ ] Shared view (`?c=0&to=name`) renders correctly in both modes

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)