### PR TITLE
[#28] Add compliment view counter

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+const VIEW_COUNT_KEY = 'compliment_view_count';
+
 // Do not reorder or delete entries — this breaks existing shared links.
 const COMPLIMENTS = [
   "You make the people around you feel seen.",
@@ -63,6 +65,21 @@ function pickRandom() {
   const next = Math.floor(Math.random() * COMPLIMENTS.length);
   currentIndex = next;
   document.getElementById('compliment').textContent = COMPLIMENTS[currentIndex];
+  incrementViewCount();
+  updateViewCountDisplay();
+}
+
+function incrementViewCount() {
+  const count = (parseInt(localStorage.getItem(VIEW_COUNT_KEY) || '0', 10)) + 1;
+  localStorage.setItem(VIEW_COUNT_KEY, count);
+}
+
+function updateViewCountDisplay() {
+  const count = parseInt(localStorage.getItem(VIEW_COUNT_KEY) || '0', 10);
+  const el = document.getElementById('view-count');
+  if (el) {
+    el.textContent = `This compliment has brightened ${count} day${count === 1 ? '' : 's'}`;
+  }
 }
 
 function handleShare() {
@@ -99,6 +116,8 @@ function renderSharedView(params) {
   }
 
   document.getElementById('compliment').textContent = COMPLIMENTS[index];
+  incrementViewCount();
+  updateViewCountDisplay();
 
   if (name) {
     const header = document.createElement('p');

--- a/index.html
+++ b/index.html
@@ -43,6 +43,8 @@
       <p class="compliment-text" id="compliment">Your compliment will appear here.</p>
     </div>
 
+    <p class="view-count" id="view-count"></p>
+
     <button class="btn" id="new-compliment-btn" type="button">New Compliment</button>
     <input
       type="text"

--- a/styles.css
+++ b/styles.css
@@ -88,6 +88,14 @@ h1 {
   transition: color 0.3s ease;
 }
 
+.view-count {
+  font-size: 0.875rem;
+  color: var(--color-subtle);
+  margin-top: 0.75rem;
+  min-height: 1.4em;
+  transition: color 0.3s ease;
+}
+
 .btn {
   background-color: var(--bg-btn);
   color: var(--color-btn-text);


### PR DESCRIPTION
## Summary

- Adds a `#view-count` element to `index.html` below the compliment card
- Tracks total compliment views in `localStorage` under the key `compliment_view_count` via `incrementViewCount()` and `updateViewCountDisplay()` in `app.js`
- Displays the count as "This compliment has brightened N days" (singular/plural handled)
- Counter increments on every new compliment shown (interactive view) and on shared-link views
- Styled subtly using the existing `--color-subtle` CSS variable to match the design system

## Test plan

- [ ] Open `index.html` — count shows "This compliment has brightened 1 day" on first load
- [ ] Click "New Compliment" repeatedly — count increments each time
- [ ] Refresh the page — count persists from localStorage
- [ ] Open a shared link (`?c=3`) — count increments and displays
- [ ] Clear localStorage — counter resets to 0 on next view

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)