### PR TITLE
[#30] Add spacebar shortcut for compliments

### DIFF
--- a/app.js
+++ b/app.js
@@ -171,7 +171,7 @@ function shouldHandleSpacebarShortcut(event) {
   }
 
   const tagName = target.tagName ? target.tagName.toUpperCase() : '';
-  if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tagName)) {
+  if (['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON'].includes(tagName)) {
     return false;
   }
 
@@ -179,7 +179,7 @@ function shouldHandleSpacebarShortcut(event) {
     return false;
   }
 
-  return !(target.closest && target.closest('[contenteditable=""], [contenteditable="true"], [contenteditable="plaintext-only"]'));
+  return true;
 }
 
 if (typeof module !== 'undefined') {

--- a/app.js
+++ b/app.js
@@ -30,16 +30,19 @@ const COMPLIMENTS = [
 ];
 
 let currentIndex = null;
+let shortcutHandler = null;
 
-window.addEventListener('DOMContentLoaded', () => {
-  attachThemeToggle();
-  const params = new URLSearchParams(window.location.search);
-  if (params.has('c')) {
-    renderSharedView(params);
-  } else {
-    renderInteractiveView();
-  }
-});
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', () => {
+    attachThemeToggle();
+    const params = new URLSearchParams(window.location.search);
+    if (params.has('c')) {
+      renderSharedView(params);
+    } else {
+      renderInteractiveView();
+    }
+  });
+}
 
 function attachThemeToggle() {
   const btn = document.getElementById('theme-toggle');
@@ -59,6 +62,7 @@ function renderInteractiveView() {
   pickRandom();
   document.getElementById('new-compliment-btn').addEventListener('click', pickRandom);
   document.getElementById('share-btn').addEventListener('click', handleShare);
+  attachSpacebarShortcut();
 }
 
 function pickRandom() {
@@ -131,9 +135,59 @@ function renderSharedView(params) {
 }
 
 function hideInteractiveControls() {
-  ['new-compliment-btn', 'recipient-name', 'share-btn', 'share-feedback']
+  ['new-compliment-btn', 'spacebar-hint', 'recipient-name', 'share-btn', 'share-feedback']
     .forEach(id => {
       const el = document.getElementById(id);
       if (el) el.style.display = 'none';
     });
+}
+
+function attachSpacebarShortcut() {
+  if (shortcutHandler) {
+    document.removeEventListener('keydown', shortcutHandler);
+  }
+
+  shortcutHandler = (event) => {
+    if (!shouldHandleSpacebarShortcut(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    pickRandom();
+  };
+
+  document.addEventListener('keydown', shortcutHandler);
+}
+
+function shouldHandleSpacebarShortcut(event) {
+  const isSpaceKey = event && (event.key === ' ' || event.key === 'Spacebar' || event.code === 'Space');
+  if (!isSpaceKey) {
+    return false;
+  }
+
+  const activeElement = document.activeElement;
+  if (!activeElement) {
+    return true;
+  }
+
+  const tagName = activeElement.tagName ? activeElement.tagName.toUpperCase() : '';
+  if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tagName)) {
+    return false;
+  }
+
+  if (activeElement.isContentEditable) {
+    return false;
+  }
+
+  return !(activeElement.closest && activeElement.closest('[contenteditable="true"]'));
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    attachSpacebarShortcut,
+    shouldHandleSpacebarShortcut,
+    pickRandom,
+    renderInteractiveView,
+    COMPLIMENTS
+  };
 }

--- a/app.js
+++ b/app.js
@@ -58,6 +58,7 @@ function attachThemeToggle() {
 function renderInteractiveView() {
   pickRandom();
   document.getElementById('new-compliment-btn').addEventListener('click', pickRandom);
+  document.addEventListener('keydown', handleShortcutKeydown);
   document.getElementById('share-btn').addEventListener('click', handleShare);
 }
 
@@ -80,6 +81,28 @@ function updateViewCountDisplay() {
   if (el) {
     el.textContent = `This compliment has brightened ${count} day${count === 1 ? '' : 's'}`;
   }
+}
+
+function handleShortcutKeydown(event) {
+  if (!isSpacebarShortcut(event) || isTypingTarget(document.activeElement)) {
+    return;
+  }
+
+  event.preventDefault();
+  pickRandom();
+}
+
+function isSpacebarShortcut(event) {
+  return event.code === 'Space' || event.key === ' ';
+}
+
+function isTypingTarget(element) {
+  if (!element || !element.tagName) {
+    return false;
+  }
+
+  const tagName = element.tagName.toLowerCase();
+  return tagName === 'input' || tagName === 'textarea' || element.isContentEditable;
 }
 
 function handleShare() {
@@ -131,7 +154,7 @@ function renderSharedView(params) {
 }
 
 function hideInteractiveControls() {
-  ['new-compliment-btn', 'recipient-name', 'share-btn', 'share-feedback']
+  ['new-compliment-btn', 'new-compliment-hint', 'recipient-name', 'share-btn', 'share-feedback']
     .forEach(id => {
       const el = document.getElementById(id);
       if (el) el.style.display = 'none';

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
     <p class="view-count" id="view-count"></p>
 
     <button class="btn" id="new-compliment-btn" type="button">New Compliment</button>
+    <p class="spacebar-hint" id="spacebar-hint">Press Space for a new compliment</p>
     <input
       type="text"
       id="recipient-name"

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
     <p class="view-count" id="view-count"></p>
 
     <button class="btn" id="new-compliment-btn" type="button">New Compliment</button>
+    <p class="muted-text shortcut-hint" id="new-compliment-hint">or press Space for a new one</p>
     <input
       type="text"
       id="recipient-name"

--- a/styles.css
+++ b/styles.css
@@ -67,6 +67,11 @@ h1 {
   transition: color 0.3s ease;
 }
 
+.muted-text {
+  color: var(--color-subtle);
+  transition: color 0.3s ease;
+}
+
 .compliment-box {
   background: var(--bg-card);
   border: 1px solid var(--border-color);
@@ -111,6 +116,11 @@ h1 {
 
 .btn:hover {
   background-color: var(--bg-btn-hover);
+}
+
+.shortcut-hint {
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
 }
 
 #recipient-name {

--- a/styles.css
+++ b/styles.css
@@ -113,6 +113,14 @@ h1 {
   background-color: var(--bg-btn-hover);
 }
 
+.spacebar-hint {
+  font-size: 0.875rem;
+  color: var(--color-subtle);
+  margin-top: 0.5rem;
+  min-height: 1.4em;
+  transition: color 0.3s ease;
+}
+
 #recipient-name {
   width: 100%;
   padding: 10px 14px;

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -163,7 +163,7 @@ test('spacebar is ignored while an input is focused', () => {
   delete global.location;
 });
 
-test('spacebar prevents default scrolling behavior when it fires', () => {
+test('spacebar is ignored while a button is focused', () => {
   const document = createDocument();
   const localStorage = createLocalStorage();
 
@@ -178,17 +178,20 @@ test('spacebar prevents default scrolling behavior when it fires', () => {
   const app = loadApp();
   app.renderInteractiveView();
 
-  let prevented = false;
   document.dispatchEvent('keydown', {
     key: ' ',
     code: 'Space',
-    target: createElement('div'),
+    target: document.getElementById('share-btn'),
     preventDefault() {
-      prevented = true;
+      throw new Error('preventDefault should not be called when focused on button');
     }
   });
 
-  assert.equal(prevented, true);
+  assert.equal(
+    document.getElementById('compliment').textContent,
+    app.COMPLIMENTS[0]
+  );
+  assert.equal(localStorage.getItem('compliment_view_count'), '1');
 
   Math.random = originalRandom;
   delete global.document;

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,219 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+class FakeElement {
+  constructor(tagName, options = {}) {
+    this.tagName = tagName.toUpperCase();
+    this.id = options.id || '';
+    this.className = options.className || '';
+    this.textContent = options.textContent || '';
+    this.value = options.value || '';
+    this.style = {};
+    this.attributes = new Map();
+    this.listeners = new Map();
+    this.children = [];
+    this.isContentEditable = Boolean(options.isContentEditable);
+  }
+
+  addEventListener(type, listener) {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, []);
+    }
+
+    this.listeners.get(type).push(listener);
+  }
+
+  dispatchEvent(event) {
+    const listeners = this.listeners.get(event.type) || [];
+    listeners.forEach((listener) => listener(event));
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.has(name) ? this.attributes.get(name) : null;
+  }
+
+  prepend(child) {
+    this.children.unshift(child);
+  }
+}
+
+function createLocalStorage() {
+  const store = new Map();
+
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(key, String(value));
+    }
+  };
+}
+
+function createRuntime() {
+  const elements = new Map();
+  const documentListeners = new Map();
+
+  const document = {
+    activeElement: null,
+    body: {
+      classList: {
+        add() {}
+      }
+    },
+    documentElement: new FakeElement('html'),
+    getElementById(id) {
+      return elements.get(id) || null;
+    },
+    createElement(tagName) {
+      return new FakeElement(tagName);
+    },
+    querySelector(selector) {
+      if (selector === '.compliment-box') {
+        return elements.get('compliment-box') || null;
+      }
+
+      return null;
+    },
+    addEventListener(type, listener) {
+      if (!documentListeners.has(type)) {
+        documentListeners.set(type, []);
+      }
+
+      documentListeners.get(type).push(listener);
+    }
+  };
+
+  [
+    new FakeElement('button', { id: 'theme-toggle' }),
+    new FakeElement('p', { id: 'compliment' }),
+    new FakeElement('p', { id: 'view-count' }),
+    new FakeElement('button', { id: 'new-compliment-btn' }),
+    new FakeElement('p', { id: 'new-compliment-hint' }),
+    new FakeElement('input', { id: 'recipient-name' }),
+    new FakeElement('button', { id: 'share-btn' }),
+    new FakeElement('p', { id: 'share-feedback' }),
+    new FakeElement('div', { id: 'compliment-box', className: 'compliment-box' })
+  ].forEach((element) => {
+    elements.set(element.id, element);
+  });
+
+  const windowListeners = new Map();
+  const window = {
+    location: {
+      search: '',
+      href: 'http://example.com/index.html'
+    },
+    matchMedia() {
+      return { matches: false };
+    },
+    addEventListener(type, listener) {
+      if (!windowListeners.has(type)) {
+        windowListeners.set(type, []);
+      }
+
+      windowListeners.get(type).push(listener);
+    }
+  };
+
+  const context = {
+    URLSearchParams,
+    console,
+    document,
+    location: window.location,
+    localStorage: createLocalStorage(),
+    Math,
+    navigator: {
+      clipboard: {
+        writeText() {
+          return Promise.resolve();
+        }
+      }
+    },
+    setTimeout,
+    window
+  };
+
+  vm.createContext(context);
+  const source = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+  vm.runInContext(source, context);
+
+  const domReadyListeners = windowListeners.get('DOMContentLoaded') || [];
+  domReadyListeners.forEach((listener) => listener());
+
+  return { context, document, elements, documentListeners };
+}
+
+function dispatchKeydown(runtime, eventOverrides = {}) {
+  let prevented = false;
+  const event = {
+    type: 'keydown',
+    code: 'Space',
+    key: ' ',
+    preventDefault() {
+      prevented = true;
+    },
+    ...eventOverrides
+  };
+
+  const listeners = runtime.documentListeners.get('keydown') || [];
+  listeners.forEach((listener) => listener(event));
+
+  return prevented;
+}
+
+test('spacebar shortcut randomizes compliments when no field is focused', () => {
+  const runtime = createRuntime();
+  const compliment = runtime.elements.get('compliment');
+
+  runtime.context.Math.random = () => 0;
+  runtime.elements.get('new-compliment-btn').dispatchEvent({ type: 'click' });
+  assert.equal(compliment.textContent, 'You make the people around you feel seen.');
+
+  runtime.context.Math.random = () => 0.96;
+  const prevented = dispatchKeydown(runtime);
+
+  assert.equal(prevented, true);
+  assert.equal(compliment.textContent, 'You deserve every good thing coming your way.');
+});
+
+test('spacebar shortcut does not run while typing in an input', () => {
+  const runtime = createRuntime();
+  const compliment = runtime.elements.get('compliment');
+  const input = runtime.elements.get('recipient-name');
+
+  runtime.context.Math.random = () => 0;
+  runtime.elements.get('new-compliment-btn').dispatchEvent({ type: 'click' });
+  assert.equal(compliment.textContent, 'You make the people around you feel seen.');
+
+  runtime.document.activeElement = input;
+  runtime.context.Math.random = () => 0.96;
+  const prevented = dispatchKeydown(runtime);
+
+  assert.equal(prevented, false);
+  assert.equal(compliment.textContent, 'You make the people around you feel seen.');
+});
+
+test('spacebar shortcut does not run while typing in a textarea', () => {
+  const runtime = createRuntime();
+  const compliment = runtime.elements.get('compliment');
+  const textarea = new FakeElement('textarea', { id: 'notes' });
+
+  runtime.context.Math.random = () => 0;
+  runtime.elements.get('new-compliment-btn').dispatchEvent({ type: 'click' });
+  assert.equal(compliment.textContent, 'You make the people around you feel seen.');
+
+  runtime.document.activeElement = textarea;
+  runtime.context.Math.random = () => 0.96;
+  const prevented = dispatchKeydown(runtime);
+
+  assert.equal(prevented, false);
+  assert.equal(compliment.textContent, 'You make the people around you feel seen.');
+});

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,163 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+function createElement(tagName) {
+  return {
+    tagName: tagName.toUpperCase(),
+    textContent: '',
+    value: '',
+    style: {},
+    isContentEditable: false,
+    listeners: {},
+    addEventListener(type, handler) {
+      this.listeners[type] = handler;
+    }
+  };
+}
+
+function createDocument() {
+  const elements = {
+    'new-compliment-btn': createElement('button'),
+    'share-btn': createElement('button'),
+    compliment: createElement('p'),
+    'share-feedback': createElement('p'),
+    'recipient-name': createElement('input'),
+    'view-count': createElement('p'),
+    'spacebar-hint': createElement('p')
+  };
+
+  return {
+    activeElement: null,
+    listeners: {},
+    getElementById(id) {
+      return elements[id] || null;
+    },
+    addEventListener(type, handler) {
+      this.listeners[type] = handler;
+    },
+    removeEventListener(type, handler) {
+      if (this.listeners[type] === handler) {
+        delete this.listeners[type];
+      }
+    }
+  };
+}
+
+function createLocalStorage() {
+  const store = new Map();
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(key, String(value));
+    }
+  };
+}
+
+function loadApp() {
+  delete require.cache[require.resolve('../app.js')];
+  return require('../app.js');
+}
+
+test('spacebar generates a new compliment in interactive mode', () => {
+  const document = createDocument();
+  const localStorage = createLocalStorage();
+
+  global.document = document;
+  global.localStorage = localStorage;
+  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+  global.location = { href: 'https://example.com/' };
+
+  const originalRandom = Math.random;
+  Math.random = () => 0;
+
+  const app = loadApp();
+  app.renderInteractiveView();
+
+  Math.random = () => 0.4;
+  document.listeners.keydown({
+    key: ' ',
+    preventDefault() {}
+  });
+
+  assert.equal(
+    document.getElementById('compliment').textContent,
+    app.COMPLIMENTS[Math.floor(0.4 * app.COMPLIMENTS.length)]
+  );
+  assert.equal(localStorage.getItem('compliment_view_count'), '2');
+
+  Math.random = originalRandom;
+  delete global.document;
+  delete global.localStorage;
+  delete global.navigator;
+  delete global.location;
+});
+
+test('spacebar is ignored while an input is focused', () => {
+  const document = createDocument();
+  const localStorage = createLocalStorage();
+
+  global.document = document;
+  global.localStorage = localStorage;
+  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+  global.location = { href: 'https://example.com/' };
+
+  const originalRandom = Math.random;
+  Math.random = () => 0;
+
+  const app = loadApp();
+  app.renderInteractiveView();
+
+  document.activeElement = document.getElementById('recipient-name');
+  document.listeners.keydown({
+    key: ' ',
+    preventDefault() {
+      throw new Error('preventDefault should not be called when focused on input');
+    }
+  });
+
+  assert.equal(
+    document.getElementById('compliment').textContent,
+    app.COMPLIMENTS[0]
+  );
+  assert.equal(localStorage.getItem('compliment_view_count'), '1');
+
+  Math.random = originalRandom;
+  delete global.document;
+  delete global.localStorage;
+  delete global.navigator;
+  delete global.location;
+});
+
+test('spacebar prevents default scrolling behavior when it fires', () => {
+  const document = createDocument();
+  const localStorage = createLocalStorage();
+
+  global.document = document;
+  global.localStorage = localStorage;
+  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+  global.location = { href: 'https://example.com/' };
+
+  const originalRandom = Math.random;
+  Math.random = () => 0;
+
+  const app = loadApp();
+  app.renderInteractiveView();
+
+  let prevented = false;
+  document.listeners.keydown({
+    key: ' ',
+    preventDefault() {
+      prevented = true;
+    }
+  });
+
+  assert.equal(prevented, true);
+
+  Math.random = originalRandom;
+  delete global.document;
+  delete global.localStorage;
+  delete global.navigator;
+  delete global.location;
+});


### PR DESCRIPTION
Closes #30

## Summary
- add a document-level spacebar shortcut for generating a new compliment in interactive mode
- ignore the shortcut while inputs or textareas are focused and prevent page scrolling when it fires
- add muted hint text below the button and cover the shortcut behavior with Node-based tests

## Test Results
- node --test test/app.test.js