### PR TITLE
[#33] Add a random background color on each page load

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,19 +55,24 @@ function generateRandomPastelColor() {
 }
 
 function applyRandomBackgroundColor(doc = document) {
-  if (!doc || !doc.documentElement || !doc.documentElement.style) {
+  if (!doc || !doc.documentElement || !doc.documentElement.style || !doc.body || !doc.body.style) {
     return null;
   }
 
   const color = generateRandomPastelColor();
   doc.documentElement.style.setProperty(RANDOM_BODY_BACKGROUND_KEY, color);
   syncBackgroundColor(doc);
+  doc.body.style.backgroundColor = color;
   return color;
 }
 
 function syncBackgroundColor(doc = document) {
   if (!doc || !doc.documentElement || !doc.documentElement.style) {
     return;
+  }
+
+  if (doc.body && doc.body.style) {
+    doc.body.style.backgroundColor = '';
   }
 
   const theme = doc.documentElement.getAttribute('data-theme');

--- a/app.js
+++ b/app.js
@@ -1,4 +1,6 @@
 const VIEW_COUNT_KEY = 'compliment_view_count';
+const RANDOM_BODY_BACKGROUND_KEY = '--bg-body-pastel';
+const ACTIVE_BODY_BACKGROUND_KEY = '--bg-body-current';
 
 // Do not reorder or delete entries — this breaks existing shared links.
 const COMPLIMENTS = [
@@ -34,6 +36,7 @@ let shortcutHandler = null;
 
 if (typeof window !== 'undefined') {
   window.addEventListener('DOMContentLoaded', () => {
+    applyRandomBackgroundColor();
     attachThemeToggle();
     const params = new URLSearchParams(window.location.search);
     if (params.has('c')) {
@@ -42,6 +45,37 @@ if (typeof window !== 'undefined') {
       renderInteractiveView();
     }
   });
+}
+
+function generateRandomPastelColor() {
+  const hue = Math.floor(Math.random() * 360);
+  const saturation = 65 + Math.floor(Math.random() * 16);
+  const lightness = 84 + Math.floor(Math.random() * 10);
+  return `hsl(${hue} ${saturation}% ${lightness}%)`;
+}
+
+function applyRandomBackgroundColor(doc = document) {
+  if (!doc || !doc.documentElement || !doc.documentElement.style) {
+    return null;
+  }
+
+  const color = generateRandomPastelColor();
+  doc.documentElement.style.setProperty(RANDOM_BODY_BACKGROUND_KEY, color);
+  syncBackgroundColor(doc);
+  return color;
+}
+
+function syncBackgroundColor(doc = document) {
+  if (!doc || !doc.documentElement || !doc.documentElement.style) {
+    return;
+  }
+
+  const theme = doc.documentElement.getAttribute('data-theme');
+  const activeColor = theme === 'dark'
+    ? 'var(--bg-body)'
+    : `var(${RANDOM_BODY_BACKGROUND_KEY}, var(--bg-body))`;
+
+  doc.documentElement.style.setProperty(ACTIVE_BODY_BACKGROUND_KEY, activeColor);
 }
 
 function attachThemeToggle() {
@@ -54,6 +88,7 @@ function attachThemeToggle() {
     const next = current === 'dark' ? 'light' : 'dark';
     document.documentElement.setAttribute('data-theme', next);
     localStorage.setItem('theme', next);
+    syncBackgroundColor();
     btn.setAttribute('aria-label', next === 'dark' ? 'Toggle light mode' : 'Toggle dark mode');
   });
 }
@@ -184,7 +219,9 @@ function shouldHandleSpacebarShortcut(event) {
 
 if (typeof module !== 'undefined') {
   module.exports = {
+    applyRandomBackgroundColor,
     attachSpacebarShortcut,
+    generateRandomPastelColor,
     shouldHandleSpacebarShortcut,
     pickRandom,
     renderInteractiveView,

--- a/styles.css
+++ b/styles.css
@@ -38,7 +38,7 @@
 
 body {
   font-family: Georgia, 'Times New Roman', serif;
-  background-color: var(--bg-body);
+  background-color: var(--bg-body-current, var(--bg-body));
   color: var(--color-text);
   min-height: 100vh;
   display: flex;

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -85,6 +85,41 @@ function createDocument() {
   };
 }
 
+function loadAppAndDispatchDomReady({ search = '', initialTheme = null } = {}) {
+  const document = createDocument();
+  const localStorage = createLocalStorage();
+
+  if (initialTheme !== null) {
+    document.documentElement.setAttribute('data-theme', initialTheme);
+  }
+
+  global.document = document;
+  global.localStorage = localStorage;
+  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+  global.location = { href: 'https://example.com/' };
+  global.window = {
+    location: { search },
+    addEventListener(type, handler) {
+      if (type === 'DOMContentLoaded') {
+        this.domReady = handler;
+      }
+    }
+  };
+
+  const app = loadApp();
+  global.window.domReady();
+
+  return { app, document, localStorage };
+}
+
+function cleanupGlobals() {
+  delete global.document;
+  delete global.localStorage;
+  delete global.navigator;
+  delete global.location;
+  delete global.window;
+}
+
 function createLocalStorage() {
   const store = new Map();
   return {
@@ -263,34 +298,18 @@ test('generateRandomPastelColor returns a predictable pastel hsl value', () => {
 });
 
 test('DOMContentLoaded applies a random background color', () => {
-  const document = createDocument();
-  const localStorage = createLocalStorage();
-
-  global.document = document;
-  global.localStorage = localStorage;
-  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
-  global.location = { href: 'https://example.com/' };
-  global.window = {
-    location: { search: '' },
-    addEventListener(type, handler) {
-      if (type === 'DOMContentLoaded') {
-        this.domReady = handler;
-      }
-    }
-  };
-
   const originalRandom = Math.random;
   let calls = 0;
   const values = [0.5, 0.25, 0.75, 0];
   Math.random = () => values[calls++];
 
-  const app = loadApp();
-  global.window.domReady();
+  const { app, document } = loadAppAndDispatchDomReady();
 
   assert.equal(
     document.documentElement.style.getPropertyValue('--bg-body-pastel'),
     'hsl(180 69% 91%)'
   );
+  assert.equal(document.body.style.backgroundColor, 'hsl(180 69% 91%)');
   assert.equal(
     document.documentElement.style.getPropertyValue('--bg-body-current'),
     'var(--bg-body-pastel, var(--bg-body))'
@@ -298,43 +317,83 @@ test('DOMContentLoaded applies a random background color', () => {
   assert.equal(document.getElementById('compliment').textContent, app.COMPLIMENTS[0]);
 
   Math.random = originalRandom;
-  delete global.document;
-  delete global.localStorage;
-  delete global.navigator;
-  delete global.location;
-  delete global.window;
+  cleanupGlobals();
 });
 
-test('theme toggle preserves the pastel color for light mode and restores theme background for dark mode', () => {
-  const document = createDocument();
-  const localStorage = createLocalStorage();
-
-  global.document = document;
-  global.localStorage = localStorage;
-  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
-  global.location = { href: 'https://example.com/' };
-  global.window = {
-    location: { search: '' },
-    addEventListener(type, handler) {
-      if (type === 'DOMContentLoaded') {
-        this.domReady = handler;
-      }
-    }
-  };
-
+test('DOMContentLoaded keeps the random pastel visible with no saved preference in light mode', () => {
   const originalRandom = Math.random;
   let calls = 0;
   const values = [0.5, 0.25, 0.75, 0];
   Math.random = () => values[calls++];
 
-  loadApp();
-  global.window.domReady();
+  const { document } = loadAppAndDispatchDomReady();
+
+  assert.equal(document.documentElement.getAttribute('data-theme'), null);
+  assert.equal(document.body.style.backgroundColor, 'hsl(180 69% 91%)');
+
+  Math.random = originalRandom;
+  cleanupGlobals();
+});
+
+test('DOMContentLoaded keeps the random pastel visible with a saved light theme', () => {
+  const originalRandom = Math.random;
+  let calls = 0;
+  const values = [0.5, 0.25, 0.75, 0];
+  Math.random = () => values[calls++];
+
+  const { document } = loadAppAndDispatchDomReady({ initialTheme: 'light' });
+
+  assert.equal(document.documentElement.getAttribute('data-theme'), 'light');
+  assert.equal(document.body.style.backgroundColor, 'hsl(180 69% 91%)');
+
+  Math.random = originalRandom;
+  cleanupGlobals();
+});
+
+test('DOMContentLoaded keeps the random pastel visible with a saved dark theme', () => {
+  const originalRandom = Math.random;
+  let calls = 0;
+  const values = [0.5, 0.25, 0.75, 0];
+  Math.random = () => values[calls++];
+
+  const { document } = loadAppAndDispatchDomReady({ initialTheme: 'dark' });
+
+  assert.equal(document.documentElement.getAttribute('data-theme'), 'dark');
+  assert.equal(document.body.style.backgroundColor, 'hsl(180 69% 91%)');
+
+  Math.random = originalRandom;
+  cleanupGlobals();
+});
+
+test('DOMContentLoaded keeps the random pastel visible with a dark system preference and no saved theme', () => {
+  const originalRandom = Math.random;
+  let calls = 0;
+  const values = [0.5, 0.25, 0.75, 0];
+  Math.random = () => values[calls++];
+
+  const { document } = loadAppAndDispatchDomReady({ initialTheme: 'dark' });
+
+  assert.equal(document.documentElement.getAttribute('data-theme'), 'dark');
+  assert.equal(document.body.style.backgroundColor, 'hsl(180 69% 91%)');
+
+  Math.random = originalRandom;
+  cleanupGlobals();
+});
+
+test('theme toggle restores theme-controlled backgrounds after the initial pastel load', () => {
+  const originalRandom = Math.random;
+  let calls = 0;
+  const values = [0.5, 0.25, 0.75, 0];
+  Math.random = () => values[calls++];
+
+  const { document, localStorage } = loadAppAndDispatchDomReady();
 
   const toggle = document.getElementById('theme-toggle');
   toggle.listeners.click[0]();
 
   assert.equal(document.documentElement.getAttribute('data-theme'), 'dark');
   assert.equal(localStorage.getItem('theme'), 'dark');
+  assert.equal(document.body.style.backgroundColor, '');
   assert.equal(
     document.documentElement.style.getPropertyValue('--bg-body-current'),
     'var(--bg-body)'
@@ -344,15 +403,12 @@ test('theme toggle preserves the pastel color for light mode and restores theme 
 
   assert.equal(document.documentElement.getAttribute('data-theme'), 'light');
   assert.equal(localStorage.getItem('theme'), 'light');
+  assert.equal(document.body.style.backgroundColor, '');
   assert.equal(
     document.documentElement.style.getPropertyValue('--bg-body-current'),
     'var(--bg-body-pastel, var(--bg-body))'
   );
 
   Math.random = originalRandom;
-  delete global.document;
-  delete global.localStorage;
-  delete global.navigator;
-  delete global.location;
-  delete global.window;
+  cleanupGlobals();
 });

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -37,12 +37,28 @@ function createDocument() {
 
   return {
     activeElement: null,
+    body: {
+      style: {},
+      classList: { add() {} }
+    },
     listeners: {},
     documentElement: {
-      getAttribute() {
-        return null;
+      attributes: {},
+      style: {
+        properties: {},
+        setProperty(name, value) {
+          this.properties[name] = value;
+        },
+        getPropertyValue(name) {
+          return this.properties[name] || '';
+        }
       },
-      setAttribute() {}
+      getAttribute() {
+        return this.attributes['data-theme'] || null;
+      },
+      setAttribute(name, value) {
+        this.attributes[name] = value;
+      }
     },
     getElementById(id) {
       return elements[id] || null;
@@ -217,7 +233,6 @@ test('shared view does not attach the document-level shortcut', () => {
     }
   };
 
-  document.body = { classList: { add() {} } };
   document.querySelector = () => ({ prepend() {} });
   document.createElement = () => createElement('p');
 
@@ -227,6 +242,114 @@ test('shared view does not attach the document-level shortcut', () => {
   assert.deepEqual(document.listeners.keydown || [], []);
   assert.equal(localStorage.getItem('compliment_view_count'), '1');
 
+  delete global.document;
+  delete global.localStorage;
+  delete global.navigator;
+  delete global.location;
+  delete global.window;
+});
+
+test('generateRandomPastelColor returns a predictable pastel hsl value', () => {
+  const originalRandom = Math.random;
+  let calls = 0;
+  const values = [0.5, 0.25, 0.75];
+  Math.random = () => values[calls++];
+
+  const app = loadApp();
+
+  assert.equal(app.generateRandomPastelColor(), 'hsl(180 69% 91%)');
+
+  Math.random = originalRandom;
+});
+
+test('DOMContentLoaded applies a random background color', () => {
+  const document = createDocument();
+  const localStorage = createLocalStorage();
+
+  global.document = document;
+  global.localStorage = localStorage;
+  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+  global.location = { href: 'https://example.com/' };
+  global.window = {
+    location: { search: '' },
+    addEventListener(type, handler) {
+      if (type === 'DOMContentLoaded') {
+        this.domReady = handler;
+      }
+    }
+  };
+
+  const originalRandom = Math.random;
+  let calls = 0;
+  const values = [0.5, 0.25, 0.75, 0];
+  Math.random = () => values[calls++];
+
+  const app = loadApp();
+  global.window.domReady();
+
+  assert.equal(
+    document.documentElement.style.getPropertyValue('--bg-body-pastel'),
+    'hsl(180 69% 91%)'
+  );
+  assert.equal(
+    document.documentElement.style.getPropertyValue('--bg-body-current'),
+    'var(--bg-body-pastel, var(--bg-body))'
+  );
+  assert.equal(document.getElementById('compliment').textContent, app.COMPLIMENTS[0]);
+
+  Math.random = originalRandom;
+  delete global.document;
+  delete global.localStorage;
+  delete global.navigator;
+  delete global.location;
+  delete global.window;
+});
+
+test('theme toggle preserves the pastel color for light mode and restores theme background for dark mode', () => {
+  const document = createDocument();
+  const localStorage = createLocalStorage();
+
+  global.document = document;
+  global.localStorage = localStorage;
+  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+  global.location = { href: 'https://example.com/' };
+  global.window = {
+    location: { search: '' },
+    addEventListener(type, handler) {
+      if (type === 'DOMContentLoaded') {
+        this.domReady = handler;
+      }
+    }
+  };
+
+  const originalRandom = Math.random;
+  let calls = 0;
+  const values = [0.5, 0.25, 0.75, 0];
+  Math.random = () => values[calls++];
+
+  loadApp();
+  global.window.domReady();
+
+  const toggle = document.getElementById('theme-toggle');
+  toggle.listeners.click[0]();
+
+  assert.equal(document.documentElement.getAttribute('data-theme'), 'dark');
+  assert.equal(localStorage.getItem('theme'), 'dark');
+  assert.equal(
+    document.documentElement.style.getPropertyValue('--bg-body-current'),
+    'var(--bg-body)'
+  );
+
+  toggle.listeners.click[0]();
+
+  assert.equal(document.documentElement.getAttribute('data-theme'), 'light');
+  assert.equal(localStorage.getItem('theme'), 'light');
+  assert.equal(
+    document.documentElement.style.getPropertyValue('--bg-body-current'),
+    'var(--bg-body-pastel, var(--bg-body))'
+  );
+
+  Math.random = originalRandom;
   delete global.document;
   delete global.localStorage;
   delete global.navigator;


### PR DESCRIPTION
Closes #33

## Summary
- add a random pastel background color that is generated on each page load
- keep the existing theme toggle behavior by routing the background through CSS variables
- add test coverage for the random color generation and page-load/theme-toggle behavior

## Testing
- node --test