### PR TITLE
[#35] Add visitor counter to the page

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 const VIEW_COUNT_KEY = 'compliment_view_count';
+const VISITOR_COUNT_KEY = 'visitor_count';
 const RANDOM_BODY_BACKGROUND_KEY = '--bg-body-pastel';
 const ACTIVE_BODY_BACKGROUND_KEY = '--bg-body-current';
 
@@ -38,6 +39,8 @@ if (typeof window !== 'undefined') {
   window.addEventListener('DOMContentLoaded', () => {
     applyRandomBackgroundColor();
     attachThemeToggle();
+    incrementVisitorCount();
+    updateVisitorCountDisplay();
     const params = new URLSearchParams(window.location.search);
     if (params.has('c')) {
       renderSharedView(params);
@@ -123,6 +126,19 @@ function updateViewCountDisplay() {
   const el = document.getElementById('view-count');
   if (el) {
     el.textContent = `This compliment has brightened ${count} day${count === 1 ? '' : 's'}`;
+  }
+}
+
+function incrementVisitorCount() {
+  const count = (parseInt(localStorage.getItem(VISITOR_COUNT_KEY) || '0', 10)) + 1;
+  localStorage.setItem(VISITOR_COUNT_KEY, count);
+}
+
+function updateVisitorCountDisplay() {
+  const count = parseInt(localStorage.getItem(VISITOR_COUNT_KEY) || '0', 10);
+  const el = document.getElementById('visitor-counter');
+  if (el) {
+    el.textContent = `You've visited ${count} time${count === 1 ? '' : 's'}`;
   }
 }
 
@@ -227,6 +243,8 @@ if (typeof module !== 'undefined') {
     applyRandomBackgroundColor,
     attachSpacebarShortcut,
     generateRandomPastelColor,
+    incrementVisitorCount,
+    updateVisitorCountDisplay,
     shouldHandleSpacebarShortcut,
     pickRandom,
     renderInteractiveView,

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
     />
     <button class="btn btn-secondary" id="share-btn" type="button">Share this compliment</button>
     <p class="share-feedback" id="share-feedback" aria-live="polite"></p>
+    <p class="visitor-counter" id="visitor-counter"></p>
   </div>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -159,6 +159,13 @@ h1 {
   transition: color 0.3s ease;
 }
 
+.visitor-counter {
+  font-size: 0.8rem;
+  color: var(--color-subtle);
+  margin-top: 1.5rem;
+  transition: color 0.3s ease;
+}
+
 .shared-view .container {
   padding: 60px 24px;
 }

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -32,7 +32,8 @@ function createDocument() {
     'share-feedback': createElement('p'),
     'recipient-name': createElement('input'),
     'view-count': createElement('p'),
-    'spacebar-hint': createElement('p')
+    'spacebar-hint': createElement('p'),
+    'visitor-counter': createElement('p')
   };
 
   return {
@@ -136,6 +137,58 @@ function loadApp() {
   delete require.cache[require.resolve('../app.js')];
   return require('../app.js');
 }
+
+test('visitor counter increments once per page load and renders message', () => {
+  const originalRandom = Math.random;
+  Math.random = () => 0;
+
+  const { document, localStorage } = loadAppAndDispatchDomReady();
+
+  assert.equal(localStorage.getItem('visitor_count'), '1');
+  assert.equal(
+    document.getElementById('visitor-counter').textContent,
+    "You've visited 1 time"
+  );
+
+  Math.random = originalRandom;
+  cleanupGlobals();
+});
+
+test('visitor counter pluralizes correctly on subsequent visits', () => {
+  const originalRandom = Math.random;
+  Math.random = () => 0;
+
+  let result = loadAppAndDispatchDomReady();
+  const store = result.localStorage;
+  cleanupGlobals();
+
+  // Simulate a second page load with the same persisted store.
+  const document = createDocument();
+  global.document = document;
+  global.localStorage = store;
+  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+  global.location = { href: 'https://example.com/' };
+  global.window = {
+    location: { search: '' },
+    addEventListener(type, handler) {
+      if (type === 'DOMContentLoaded') {
+        this.domReady = handler;
+      }
+    }
+  };
+
+  loadApp();
+  global.window.domReady();
+
+  assert.equal(store.getItem('visitor_count'), '2');
+  assert.equal(
+    document.getElementById('visitor-counter').textContent,
+    "You've visited 2 times"
+  );
+
+  Math.random = originalRandom;
+  cleanupGlobals();
+});
 
 test('spacebar generates a new compliment in interactive mode', () => {
   const document = createDocument();


### PR DESCRIPTION
## Summary
- Add a visitor counter at the bottom of the page that tracks page opens via localStorage
- Counter increments once per page load (separate from the existing per-compliment view count) and renders as "You've visited N time(s)"
- Add unit tests covering first-visit and subsequent-visit pluralization

Closes #35

## Test plan
- [x] `node --test test/app.test.js` — all 13 tests pass
- [ ] Manually verify counter persists and increments on each page reload