### PR TITLE
[#37] Add confetti animation on new compliment

### DIFF
--- a/app.js
+++ b/app.js
@@ -114,6 +114,85 @@ function pickRandom() {
   document.getElementById('compliment').textContent = COMPLIMENTS[currentIndex];
   incrementViewCount();
   updateViewCountDisplay();
+  triggerConfetti();
+}
+
+const CONFETTI_COLORS = ['#ff5e7e', '#ffbe3d', '#3ddc97', '#5ab2ff', '#c77dff', '#ff9f68'];
+
+function triggerConfetti() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  if (typeof window.requestAnimationFrame !== 'function') return;
+  if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+  const canvas = document.getElementById('confetti-canvas');
+  if (!canvas || typeof canvas.getContext !== 'function') return;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  const dpr = window.devicePixelRatio || 1;
+  const width = window.innerWidth || document.documentElement.clientWidth || 800;
+  const height = window.innerHeight || document.documentElement.clientHeight || 600;
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+  canvas.style.width = width + 'px';
+  canvas.style.height = height + 'px';
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+  const particles = [];
+  const count = 80;
+  const originX = width / 2;
+  const originY = height / 3;
+  for (let i = 0; i < count; i++) {
+    const angle = Math.random() * Math.PI * 2;
+    const speed = 4 + Math.random() * 6;
+    particles.push({
+      x: originX,
+      y: originY,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed - 2,
+      size: 5 + Math.random() * 5,
+      color: CONFETTI_COLORS[Math.floor(Math.random() * CONFETTI_COLORS.length)],
+      rotation: Math.random() * Math.PI * 2,
+      vr: (Math.random() - 0.5) * 0.3,
+      life: 1
+    });
+  }
+
+  const gravity = 0.18;
+  const drag = 0.99;
+  const fade = 0.012;
+  const start = Date.now();
+  const maxDuration = 1800;
+
+  function frame() {
+    ctx.clearRect(0, 0, width, height);
+    let alive = 0;
+    for (const p of particles) {
+      if (p.life <= 0) continue;
+      p.vx *= drag;
+      p.vy = p.vy * drag + gravity;
+      p.x += p.vx;
+      p.y += p.vy;
+      p.rotation += p.vr;
+      p.life -= fade;
+      if (p.life <= 0 || p.y > height + 40) continue;
+      alive++;
+      ctx.save();
+      ctx.globalAlpha = Math.max(0, p.life);
+      ctx.translate(p.x, p.y);
+      ctx.rotate(p.rotation);
+      ctx.fillStyle = p.color;
+      ctx.fillRect(-p.size / 2, -p.size / 2, p.size, p.size * 0.5);
+      ctx.restore();
+    }
+    if (alive > 0 && Date.now() - start < maxDuration) {
+      window.requestAnimationFrame(frame);
+    } else {
+      ctx.clearRect(0, 0, width, height);
+    }
+  }
+
+  window.requestAnimationFrame(frame);
 }
 
 function incrementViewCount() {
@@ -248,6 +327,7 @@ if (typeof module !== 'undefined') {
     shouldHandleSpacebarShortcut,
     pickRandom,
     renderInteractiveView,
+    triggerConfetti,
     COMPLIMENTS
   };
 }

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <script src="app.js" defer></script>
 </head>
 <body>
+  <canvas class="confetti-canvas" id="confetti-canvas" aria-hidden="true"></canvas>
   <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle dark mode">
     <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
       <circle cx="12" cy="12" r="5"/>

--- a/styles.css
+++ b/styles.css
@@ -214,3 +214,18 @@ h1 {
 [data-theme="dark"] .icon-moon {
   display: none;
 }
+
+.confetti-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 9999;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .confetti-canvas {
+    display: none;
+  }
+}

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -337,6 +337,70 @@ test('shared view does not attach the document-level shortcut', () => {
   delete global.window;
 });
 
+test('triggerConfetti draws onto the confetti canvas when invoked', () => {
+  const document = createDocument();
+  const ctxCalls = [];
+  const ctx = new Proxy({}, {
+    get(_, key) {
+      return (...args) => { ctxCalls.push([key, args]); };
+    },
+    set() { return true; }
+  });
+  const canvas = createElement('canvas');
+  canvas.getContext = () => ctx;
+  document.getElementById = (id) => {
+    if (id === 'confetti-canvas') return canvas;
+    return null;
+  };
+
+  let rafCalls = 0;
+  global.document = document;
+  global.localStorage = createLocalStorage();
+  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+  global.location = { href: 'https://example.com/' };
+  global.window = {
+    innerWidth: 800,
+    innerHeight: 600,
+    devicePixelRatio: 1,
+    requestAnimationFrame(fn) { rafCalls++; return 0; },
+    matchMedia: () => ({ matches: false }),
+    addEventListener() {}
+  };
+
+  const app = loadApp();
+  app.triggerConfetti();
+
+  assert.equal(rafCalls, 1);
+  assert.equal(canvas.width, 800);
+  assert.equal(canvas.height, 600);
+
+  cleanupGlobals();
+});
+
+test('triggerConfetti is a no-op when the user prefers reduced motion', () => {
+  const document = createDocument();
+  let getContextCalls = 0;
+  const canvas = createElement('canvas');
+  canvas.getContext = () => { getContextCalls++; return {}; };
+  document.getElementById = (id) => (id === 'confetti-canvas' ? canvas : null);
+
+  global.document = document;
+  global.localStorage = createLocalStorage();
+  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+  global.location = { href: 'https://example.com/' };
+  global.window = {
+    requestAnimationFrame() {},
+    matchMedia: (q) => ({ matches: q.includes('reduce') }),
+    addEventListener() {}
+  };
+
+  const app = loadApp();
+  app.triggerConfetti();
+
+  assert.equal(getContextCalls, 0);
+  cleanupGlobals();
+});
+
 test('generateRandomPastelColor returns a predictable pastel hsl value', () => {
   const originalRandom = Math.random;
   let calls = 0;


### PR DESCRIPTION
## Summary
- Adds a lightweight canvas-based confetti burst that fires whenever a new compliment is rendered.
- No external libraries; pure 2D canvas particle system with gravity, drag, rotation, and fade.
- Respects `prefers-reduced-motion` (disabled via CSS and an early return in JS).

## Implementation
- `index.html`: full-screen `<canvas id="confetti-canvas">` overlay (pointer-events: none, aria-hidden).
- `styles.css`: positions the canvas as a fixed top-layer overlay; hidden under reduced-motion.
- `app.js`: `triggerConfetti()` is invoked from `pickRandom()` so it fires on button click and on the spacebar shortcut. Guards on `window`/`document`/`requestAnimationFrame` keep it test-safe.

## Test plan
- [x] `node --test test/app.test.js` — 15/15 passing
- [x] New tests cover: triggerConfetti draws to the canvas, and is a no-op under reduced motion
- [ ] Manual: open `index.html`, click "New Compliment" — confetti bursts; press spacebar — confetti bursts; toggle dark mode — still works

Closes #37