### PR TITLE
[#39] Add confetti animation on new compliment

### DIFF
--- a/app.js
+++ b/app.js
@@ -103,17 +103,20 @@ function attachThemeToggle() {
 
 function renderInteractiveView() {
   pickRandom();
-  document.getElementById('new-compliment-btn').addEventListener('click', pickRandom);
+  document.getElementById('new-compliment-btn').addEventListener('click', () => pickRandom(true));
   document.getElementById('share-btn').addEventListener('click', handleShare);
   attachSpacebarShortcut();
 }
 
-function pickRandom() {
+function pickRandom(celebrate = false) {
   const next = Math.floor(Math.random() * COMPLIMENTS.length);
   currentIndex = next;
   document.getElementById('compliment').textContent = COMPLIMENTS[currentIndex];
   incrementViewCount();
   updateViewCountDisplay();
+  if (celebrate) {
+    triggerConfetti();
+  }
 }
 
 function incrementViewCount() {
@@ -209,7 +212,7 @@ function attachSpacebarShortcut() {
     }
 
     event.preventDefault();
-    pickRandom();
+    pickRandom(true);
   };
 
   document.addEventListener('keydown', shortcutHandler);
@@ -238,6 +241,86 @@ function shouldHandleSpacebarShortcut(event) {
   return true;
 }
 
+const CONFETTI_COLORS = ['#ff6b6b', '#ffd93d', '#6bcB77', '#4d96ff', '#c780fa', '#ff9f68'];
+
+function triggerConfetti() {
+  if (typeof document === 'undefined') return;
+  const canvas = document.getElementById('confetti-canvas');
+  if (!canvas || typeof canvas.getContext !== 'function') return;
+
+  const win = typeof window !== 'undefined' ? window : null;
+  if (win && win.matchMedia && win.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    return;
+  }
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  const dpr = (win && win.devicePixelRatio) || 1;
+  const width = (win && win.innerWidth) || canvas.clientWidth || 800;
+  const height = (win && win.innerHeight) || canvas.clientHeight || 600;
+  canvas.width = Math.floor(width * dpr);
+  canvas.height = Math.floor(height * dpr);
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+  const particleCount = 80;
+  const originX = width / 2;
+  const originY = height / 2;
+  const particles = [];
+  for (let i = 0; i < particleCount; i++) {
+    const angle = Math.random() * Math.PI * 2;
+    const speed = 4 + Math.random() * 5;
+    particles.push({
+      x: originX,
+      y: originY,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed - 2,
+      size: 5 + Math.random() * 5,
+      rotation: Math.random() * Math.PI * 2,
+      vr: (Math.random() - 0.5) * 0.3,
+      color: CONFETTI_COLORS[Math.floor(Math.random() * CONFETTI_COLORS.length)],
+      life: 1
+    });
+  }
+
+  const gravity = 0.18;
+  const drag = 0.985;
+  const fadeStart = 40;
+  let frame = 0;
+
+  const raf = (win && win.requestAnimationFrame) || ((cb) => setTimeout(() => cb(Date.now()), 16));
+
+  function step() {
+    frame++;
+    ctx.clearRect(0, 0, width, height);
+    let alive = false;
+    for (const p of particles) {
+      p.vx *= drag;
+      p.vy = p.vy * drag + gravity;
+      p.x += p.vx;
+      p.y += p.vy;
+      p.rotation += p.vr;
+      if (frame > fadeStart) p.life -= 0.02;
+      if (p.life <= 0 || p.y > height + 50) continue;
+      alive = true;
+      ctx.save();
+      ctx.globalAlpha = Math.max(0, p.life);
+      ctx.translate(p.x, p.y);
+      ctx.rotate(p.rotation);
+      ctx.fillStyle = p.color;
+      ctx.fillRect(-p.size / 2, -p.size / 2, p.size, p.size * 0.6);
+      ctx.restore();
+    }
+    if (alive && frame < 200) {
+      raf(step);
+    } else {
+      ctx.clearRect(0, 0, width, height);
+    }
+  }
+
+  raf(step);
+}
+
 if (typeof module !== 'undefined') {
   module.exports = {
     applyRandomBackgroundColor,
@@ -248,6 +331,7 @@ if (typeof module !== 'undefined') {
     shouldHandleSpacebarShortcut,
     pickRandom,
     renderInteractiveView,
+    triggerConfetti,
     COMPLIMENTS
   };
 }

--- a/app.js
+++ b/app.js
@@ -109,12 +109,13 @@ function renderInteractiveView() {
 }
 
 function pickRandom(celebrate = false) {
+  const previousIndex = currentIndex;
   const next = Math.floor(Math.random() * COMPLIMENTS.length);
   currentIndex = next;
   document.getElementById('compliment').textContent = COMPLIMENTS[currentIndex];
   incrementViewCount();
   updateViewCountDisplay();
-  if (celebrate) {
+  if (celebrate && next !== previousIndex) {
     triggerConfetti();
   }
 }

--- a/index.html
+++ b/index.html
@@ -58,5 +58,6 @@
     <p class="share-feedback" id="share-feedback" aria-live="polite"></p>
     <p class="visitor-counter" id="visitor-counter"></p>
   </div>
+  <canvas class="confetti-canvas" id="confetti-canvas" aria-hidden="true"></canvas>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -214,3 +214,18 @@ h1 {
 [data-theme="dark"] .icon-moon {
   display: none;
 }
+
+.confetti-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 9999;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .confetti-canvas {
+    display: none;
+  }
+}

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -433,6 +433,96 @@ test('DOMContentLoaded keeps the random pastel visible with a dark system prefer
   cleanupGlobals();
 });
 
+test('triggerConfetti is a no-op when no canvas element exists', () => {
+  const document = createDocument();
+  global.document = document;
+
+  const app = loadApp();
+
+  assert.doesNotThrow(() => app.triggerConfetti());
+
+  delete global.document;
+});
+
+test('triggerConfetti draws particles on the canvas when present', () => {
+  const document = createDocument();
+  let clearCalls = 0;
+  let fillRectCalls = 0;
+  const ctx = {
+    setTransform() {},
+    clearRect() { clearCalls++; },
+    save() {},
+    restore() {},
+    translate() {},
+    rotate() {},
+    fillRect() { fillRectCalls++; },
+    set globalAlpha(_v) {},
+    set fillStyle(_v) {}
+  };
+  const canvas = createElement('canvas');
+  canvas.getContext = () => ctx;
+  canvas.clientWidth = 800;
+  canvas.clientHeight = 600;
+  const originalGetElementById = document.getElementById.bind(document);
+  document.getElementById = (id) => {
+    if (id === 'confetti-canvas') return canvas;
+    return originalGetElementById(id);
+  };
+
+  let rafCalls = 0;
+  let pendingStep = null;
+  global.document = document;
+  global.window = {
+    innerWidth: 800,
+    innerHeight: 600,
+    devicePixelRatio: 1,
+    matchMedia: () => ({ matches: false }),
+    requestAnimationFrame: (cb) => { rafCalls++; pendingStep = cb; },
+    addEventListener: () => {}
+  };
+
+  const app = loadApp();
+  app.triggerConfetti();
+
+  assert.ok(rafCalls >= 1, 'expected animation frame to be requested');
+  if (pendingStep) pendingStep(0);
+  assert.ok(clearCalls >= 1);
+  assert.ok(fillRectCalls > 0, 'expected particles to be drawn');
+
+  delete global.document;
+  delete global.window;
+});
+
+test('triggerConfetti respects prefers-reduced-motion', () => {
+  const document = createDocument();
+  let getContextCalls = 0;
+  const canvas = createElement('canvas');
+  canvas.getContext = () => { getContextCalls++; return {}; };
+  const originalGetElementById = document.getElementById.bind(document);
+  document.getElementById = (id) => {
+    if (id === 'confetti-canvas') return canvas;
+    return originalGetElementById(id);
+  };
+
+  global.document = document;
+  global.window = {
+    innerWidth: 800,
+    innerHeight: 600,
+    devicePixelRatio: 1,
+    matchMedia: (q) => ({ matches: q.includes('reduce') }),
+    requestAnimationFrame: () => {},
+    addEventListener: () => {}
+  };
+
+  const app = loadApp();
+  app.triggerConfetti();
+
+  assert.equal(getContextCalls, 0);
+
+  delete global.document;
+  delete global.window;
+});
+
 test('theme toggle restores theme-controlled backgrounds after the initial pastel load', () => {
   const originalRandom = Math.random;
   let calls = 0;

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -555,3 +555,51 @@ test('theme toggle restores theme-controlled backgrounds after the initial paste
   Math.random = originalRandom;
   cleanupGlobals();
 });
+
+test('pickRandom does not trigger confetti when the same compliment is picked again', () => {
+  const originalRandom = Math.random;
+  Math.random = () => 0;
+
+  const document = createDocument();
+  let getContextCalls = 0;
+  const ctx = {
+    setTransform() {}, clearRect() {}, save() {}, restore() {},
+    translate() {}, rotate() {}, fillRect() {},
+    set globalAlpha(_v) {}, set fillStyle(_v) {}
+  };
+  const canvas = createElement('canvas');
+  canvas.getContext = () => { getContextCalls++; return ctx; };
+  canvas.clientWidth = 800;
+  canvas.clientHeight = 600;
+  const originalGetElementById = document.getElementById.bind(document);
+  document.getElementById = (id) => {
+    if (id === 'confetti-canvas') return canvas;
+    return originalGetElementById(id);
+  };
+
+  global.document = document;
+  global.localStorage = createLocalStorage();
+  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+  global.location = { href: 'https://example.com/' };
+  global.window = {
+    location: { search: '' },
+    innerWidth: 800,
+    innerHeight: 600,
+    devicePixelRatio: 1,
+    matchMedia: () => ({ matches: false }),
+    requestAnimationFrame: () => {},
+    addEventListener(type, handler) {
+      if (type === 'DOMContentLoaded') this.domReady = handler;
+    }
+  };
+
+  loadApp();
+  global.window.domReady();
+
+  document.getElementById('new-compliment-btn').listeners.click[0]();
+
+  assert.equal(getContextCalls, 0, 'confetti must not fire when the new pick repeats the current compliment');
+
+  Math.random = originalRandom;
+  cleanupGlobals();
+});


### PR DESCRIPTION
## Summary
- Adds a short canvas-based confetti burst when the user gets a new compliment via the button or spacebar shortcut
- No external libraries — vanilla JS + a single fullscreen `<canvas>` overlay
- Skips the initial compliment shown on page load and the shared-link view; honors `prefers-reduced-motion`

## Review round 1 fix
- Confetti previously fired on every celebratory pick, including when `Math.random` returned the already-displayed index. `pickRandom` now compares the new index against the previous one and only calls `triggerConfetti` when they differ, so confetti lines up with what the user actually sees on screen.
- New regression test pins `Math.random` to produce a repeated pick and asserts the confetti canvas context is never requested on the second click.

## Test plan
- [x] `node --test test/app.test.js` — all 17 tests pass (4 confetti-related, including the new repeated-pick regression)
- [ ] Manual: click "New Compliment" → confetti burst plays for a new compliment
- [ ] Manual: press spacebar → confetti burst plays for a new compliment
- [ ] Manual: with reduced-motion enabled → no confetti
- [ ] Manual: shared-link view → no confetti

Closes #39