### PR TITLE
[#43] Smoothly fade compliment text on change

### DIFF
--- a/app.js
+++ b/app.js
@@ -110,12 +110,38 @@ function renderInteractiveView() {
   attachSpacebarShortcut();
 }
 
+function setComplimentText(text) {
+  if (typeof document === 'undefined') return;
+  const el = document.getElementById('compliment');
+  if (!el) return;
+
+  const win = typeof window !== 'undefined' ? window : null;
+  const raf = win && typeof win.requestAnimationFrame === 'function'
+    ? win.requestAnimationFrame.bind(win)
+    : null;
+  const reduceMotion = !!(win && win.matchMedia && win.matchMedia('(prefers-reduced-motion: reduce)').matches);
+
+  if (!raf || reduceMotion || !el.style) {
+    el.textContent = text;
+    if (el.style) el.style.opacity = '';
+    return;
+  }
+
+  el.style.opacity = '0';
+  raf(() => {
+    el.textContent = text;
+    raf(() => {
+      el.style.opacity = '1';
+    });
+  });
+}
+
 function pickRandom(celebrate = false) {
   const previousIndex = currentIndex;
   const next = Math.floor(Math.random() * COMPLIMENTS.length);
   currentIndex = next;
   const text = COMPLIMENTS[currentIndex];
-  document.getElementById('compliment').textContent = text;
+  setComplimentText(text);
   incrementViewCount();
   updateViewCountDisplay();
   recordComplimentInHistory(text);
@@ -242,14 +268,13 @@ function renderSharedView(params) {
   const name = params.get('to') || null;
 
   if (isNaN(index) || index < 0 || index >= COMPLIMENTS.length) {
-    document.getElementById('compliment').textContent =
-      "This link doesn't seem right — try generating a new compliment.";
+    setComplimentText("This link doesn't seem right — try generating a new compliment.");
     hideInteractiveControls();
     return;
   }
 
   const sharedText = COMPLIMENTS[index];
-  document.getElementById('compliment').textContent = sharedText;
+  setComplimentText(sharedText);
   incrementViewCount();
   updateViewCountDisplay();
   recordComplimentInHistory(sharedText);
@@ -403,6 +428,7 @@ if (typeof module !== 'undefined') {
     updateVisitorCountDisplay,
     shouldHandleSpacebarShortcut,
     pickRandom,
+    setComplimentText,
     renderInteractiveView,
     triggerConfetti,
     getComplimentHistory,

--- a/app.js
+++ b/app.js
@@ -110,30 +110,51 @@ function renderInteractiveView() {
   attachSpacebarShortcut();
 }
 
+const COMPLIMENT_FADE_MS = 350;
+
 function setComplimentText(text) {
   if (typeof document === 'undefined') return;
   const el = document.getElementById('compliment');
   if (!el) return;
 
   const win = typeof window !== 'undefined' ? window : null;
-  const raf = win && typeof win.requestAnimationFrame === 'function'
-    ? win.requestAnimationFrame.bind(win)
-    : null;
   const reduceMotion = !!(win && win.matchMedia && win.matchMedia('(prefers-reduced-motion: reduce)').matches);
+  const canTransition = !!(
+    win &&
+    typeof win.setTimeout === 'function' &&
+    el.style &&
+    typeof el.addEventListener === 'function'
+  );
 
-  if (!raf || reduceMotion || !el.style) {
+  if (reduceMotion || !canTransition) {
     el.textContent = text;
     if (el.style) el.style.opacity = '';
     return;
   }
 
-  el.style.opacity = '0';
-  raf(() => {
+  // Defer the swap until the fade-out transition has actually completed,
+  // not on the next animation frame. transitionend fires when opacity hits 0;
+  // the setTimeout is a safety net in case transitionend never fires
+  // (e.g. element detached, transition cancelled).
+  let swapped = false;
+  const swap = () => {
+    if (swapped) return;
+    swapped = true;
+    if (typeof el.removeEventListener === 'function') {
+      el.removeEventListener('transitionend', onEnd);
+    }
     el.textContent = text;
-    raf(() => {
-      el.style.opacity = '1';
-    });
-  });
+    el.style.opacity = '1';
+  };
+  const onEnd = (event) => {
+    if (event && event.propertyName && event.propertyName !== 'opacity') return;
+    swap();
+  };
+
+  el.addEventListener('transitionend', onEnd);
+  el.style.opacity = '0';
+
+  win.setTimeout(swap, COMPLIMENT_FADE_MS + 50);
 }
 
 function pickRandom(celebrate = false) {

--- a/styles.css
+++ b/styles.css
@@ -85,7 +85,14 @@ h1 {
   font-size: 1.25rem;
   font-style: italic;
   color: var(--color-muted);
-  transition: color 0.3s ease;
+  opacity: 1;
+  transition: color 0.3s ease, opacity 0.35s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .compliment-text {
+    transition: color 0.3s ease;
+  }
 }
 
 .view-count {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -718,7 +718,7 @@ test('compliment history preserves consecutive duplicates in newest-first order'
   cleanupGlobals();
 });
 
-test('setComplimentText fades out, swaps text, and fades in via requestAnimationFrame', () => {
+test('setComplimentText defers the swap until after the fade-out transition completes', () => {
   const document = createDocument();
   global.document = document;
   global.localStorage = createLocalStorage();
@@ -726,10 +726,10 @@ test('setComplimentText fades out, swaps text, and fades in via requestAnimation
   global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
   global.location = { href: 'https://example.com/' };
 
-  const rafQueue = [];
+  const timeouts = [];
   global.window = {
     matchMedia: () => ({ matches: false }),
-    requestAnimationFrame: (cb) => { rafQueue.push(cb); return rafQueue.length; },
+    setTimeout: (cb, delay) => { timeouts.push({ cb, delay }); return timeouts.length; },
     addEventListener: () => {}
   };
 
@@ -739,17 +739,66 @@ test('setComplimentText fades out, swaps text, and fades in via requestAnimation
 
   app.setComplimentText('new text');
 
-  // fade-out kicked in immediately, text not yet swapped
+  // Fade-out begins immediately, but the text MUST still be the old value —
+  // swapping before opacity reaches 0 would cause a visible flash.
   assert.equal(el.style.opacity, '0');
   assert.equal(el.textContent, 'old text');
 
-  // first raf: swap text while still at opacity 0
-  rafQueue.shift()();
+  // A transitionend listener must be registered so the swap can be
+  // triggered by the actual end of the opacity transition.
+  assert.ok(el.listeners.transitionend && el.listeners.transitionend.length > 0,
+    'expected a transitionend listener to be registered on the compliment element');
+
+  // The fallback timeout must match the CSS fade duration (350ms ± a small
+  // safety margin) — never zero or a single animation frame.
+  assert.ok(timeouts.length > 0, 'expected a fallback setTimeout to be scheduled');
+  assert.ok(timeouts[0].delay >= 300 && timeouts[0].delay <= 500,
+    `fallback delay ${timeouts[0].delay}ms must be within 300–500ms (CSS fade is 350ms)`);
+
+  // Simulating the end of the opacity fade-out must atomically swap the text
+  // and trigger the fade-in by restoring opacity to 1.
+  el.listeners.transitionend[0]({ propertyName: 'opacity', target: el });
   assert.equal(el.textContent, 'new text');
+  assert.equal(el.style.opacity, '1');
+
+  // Fallback timer firing later must be a no-op (idempotent swap).
+  timeouts[0].cb();
+  assert.equal(el.textContent, 'new text');
+  assert.equal(el.style.opacity, '1');
+
+  cleanupGlobals();
+  delete global.window;
+});
+
+test('setComplimentText falls back to a timer when transitionend never fires', () => {
+  const document = createDocument();
+  global.document = document;
+  global.localStorage = createLocalStorage();
+  global.sessionStorage = createSessionStorage();
+  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+  global.location = { href: 'https://example.com/' };
+
+  const timeouts = [];
+  global.window = {
+    matchMedia: () => ({ matches: false }),
+    setTimeout: (cb) => { timeouts.push(cb); return timeouts.length; },
+    addEventListener: () => {}
+  };
+
+  const app = loadApp();
+  const el = document.getElementById('compliment');
+  el.textContent = 'old text';
+
+  app.setComplimentText('new text');
+
+  // Even before the fallback fires, the text must not have changed yet.
+  assert.equal(el.textContent, 'old text');
   assert.equal(el.style.opacity, '0');
 
-  // second raf: fade back in
-  rafQueue.shift()();
+  // Firing the fallback timer (transitionend never arrived) completes the swap.
+  assert.equal(timeouts.length, 1);
+  timeouts[0]();
+  assert.equal(el.textContent, 'new text');
   assert.equal(el.style.opacity, '1');
 
   cleanupGlobals();
@@ -765,14 +814,19 @@ test('setComplimentText updates synchronously when prefers-reduced-motion is set
   global.location = { href: 'https://example.com/' };
   global.window = {
     matchMedia: (q) => ({ matches: q.includes('reduce') }),
-    requestAnimationFrame: () => { throw new Error('raf must not be used when reduced motion is requested'); },
+    setTimeout: () => { throw new Error('timers must not be used when reduced motion is requested'); },
     addEventListener: () => {}
   };
 
   const app = loadApp();
+  const el = document.getElementById('compliment');
+  el.textContent = 'old';
   app.setComplimentText('hello');
 
-  assert.equal(document.getElementById('compliment').textContent, 'hello');
+  // Synchronous swap, no fade scheduling, no transitionend listener.
+  assert.equal(el.textContent, 'hello');
+  assert.ok(!el.listeners.transitionend || el.listeners.transitionend.length === 0,
+    'no transitionend listener should be registered under reduced motion');
 
   cleanupGlobals();
   delete global.window;

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -718,6 +718,66 @@ test('compliment history preserves consecutive duplicates in newest-first order'
   cleanupGlobals();
 });
 
+test('setComplimentText fades out, swaps text, and fades in via requestAnimationFrame', () => {
+  const document = createDocument();
+  global.document = document;
+  global.localStorage = createLocalStorage();
+  global.sessionStorage = createSessionStorage();
+  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+  global.location = { href: 'https://example.com/' };
+
+  const rafQueue = [];
+  global.window = {
+    matchMedia: () => ({ matches: false }),
+    requestAnimationFrame: (cb) => { rafQueue.push(cb); return rafQueue.length; },
+    addEventListener: () => {}
+  };
+
+  const app = loadApp();
+  const el = document.getElementById('compliment');
+  el.textContent = 'old text';
+
+  app.setComplimentText('new text');
+
+  // fade-out kicked in immediately, text not yet swapped
+  assert.equal(el.style.opacity, '0');
+  assert.equal(el.textContent, 'old text');
+
+  // first raf: swap text while still at opacity 0
+  rafQueue.shift()();
+  assert.equal(el.textContent, 'new text');
+  assert.equal(el.style.opacity, '0');
+
+  // second raf: fade back in
+  rafQueue.shift()();
+  assert.equal(el.style.opacity, '1');
+
+  cleanupGlobals();
+  delete global.window;
+});
+
+test('setComplimentText updates synchronously when prefers-reduced-motion is set', () => {
+  const document = createDocument();
+  global.document = document;
+  global.localStorage = createLocalStorage();
+  global.sessionStorage = createSessionStorage();
+  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+  global.location = { href: 'https://example.com/' };
+  global.window = {
+    matchMedia: (q) => ({ matches: q.includes('reduce') }),
+    requestAnimationFrame: () => { throw new Error('raf must not be used when reduced motion is requested'); },
+    addEventListener: () => {}
+  };
+
+  const app = loadApp();
+  app.setComplimentText('hello');
+
+  assert.equal(document.getElementById('compliment').textContent, 'hello');
+
+  cleanupGlobals();
+  delete global.window;
+});
+
 test('compliment history is silently ignored when sessionStorage is unavailable', () => {
   const document = createDocument();
   global.document = document;


### PR DESCRIPTION
Closes #43

## Summary
Fades the compliment text on every change using a pure CSS opacity transition (350ms ease) — no JS animation libraries.

## Sequence
1. JS sets `opacity: 0` on `#compliment`, kicking off the CSS fade-out.
2. A `transitionend` listener (with a matching `setTimeout` safety net) waits for the opacity transition to finish.
3. Only then does the text swap, and `opacity` is restored to `1`, triggering the fade-in via the same CSS transition.

`prefers-reduced-motion: reduce` and environments without a real `window`/`setTimeout` fall back to a synchronous text swap with no animation.

## Revision (round 2)
Addresses both reviewer findings on PR #44:
- **Major — animation timing:** Replaced the previous double-`requestAnimationFrame` swap (which fired ~16ms after the call, long before the 350ms fade-out completed) with a `transitionend`-driven swap, plus a 400ms `setTimeout` fallback. The text now stays visible through the entire fade-out interval.
- **Minor — test correctness:** Rewrote the animation tests so they no longer assert an immediate raf-based swap. The tests now assert that the old text is still present after `setComplimentText` returns, that a `transitionend` listener is registered, and that the swap only happens when `transitionend` (or the fallback timer) fires. A second test covers the timer fallback path. The reduced-motion test was updated to forbid the timer instead of `requestAnimationFrame`.

## Test plan
- [x] `node --test test/app.test.js` (24/24 passing)
- [ ] Manually verify in a browser: clicking the new-compliment button shows the old text fading out, then the new text fading in (no flash).
- [ ] Verify with DevTools `prefers-reduced-motion: reduce` emulation: text swaps instantly with no fade.