### PR TITLE
[#45] Add left sidebar for recent compliments with responsive layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -181,6 +181,16 @@ function getSessionStorage() {
   return null;
 }
 
+function formatRelativeTime(timestamp) {
+  const diffMs = Date.now() - timestamp;
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffSec < 60) return 'Just now';
+  if (diffMin < 60) return `${diffMin} minute${diffMin === 1 ? '' : 's'} ago`;
+  return `${diffHour} hour${diffHour === 1 ? '' : 's'} ago`;
+}
+
 function getComplimentHistory() {
   const store = getSessionStorage();
   if (!store) return [];
@@ -188,7 +198,12 @@ function getComplimentHistory() {
     const raw = store.getItem(COMPLIMENT_HISTORY_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.filter(item => typeof item === 'string') : [];
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map(item => {
+      if (typeof item === 'string') return { text: item, timestamp: Date.now() };
+      if (item && typeof item.text === 'string' && typeof item.timestamp === 'number') return item;
+      return null;
+    }).filter(Boolean);
   } catch (e) {
     return [];
   }
@@ -198,7 +213,7 @@ function recordComplimentInHistory(text) {
   const store = getSessionStorage();
   if (!store || typeof text !== 'string') return;
   const history = getComplimentHistory();
-  history.unshift(text);
+  history.unshift({ text, timestamp: Date.now() });
   if (history.length > COMPLIMENT_HISTORY_LIMIT) {
     history.length = COMPLIMENT_HISTORY_LIMIT;
   }
@@ -220,10 +235,20 @@ function renderComplimentHistory() {
     list.removeChild(list.firstChild);
   }
 
-  for (const text of history) {
+  for (const entry of history) {
     const item = document.createElement('li');
     item.className = 'compliment-history-item';
-    item.textContent = text;
+
+    const textEl = document.createElement('span');
+    textEl.className = 'compliment-history-text';
+    textEl.textContent = entry.text;
+
+    const timeEl = document.createElement('span');
+    timeEl.className = 'compliment-history-time';
+    timeEl.textContent = formatRelativeTime(entry.timestamp);
+
+    item.appendChild(textEl);
+    item.appendChild(timeEl);
     list.appendChild(item);
   }
 
@@ -452,6 +477,7 @@ if (typeof module !== 'undefined') {
     setComplimentText,
     renderInteractiveView,
     triggerConfetti,
+    formatRelativeTime,
     getComplimentHistory,
     recordComplimentInHistory,
     renderComplimentHistory,

--- a/index.html
+++ b/index.html
@@ -35,33 +35,35 @@
       <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
     </svg>
   </button>
-  <div class="container">
-    <h1>Compliment Mirror</h1>
-    <p class="subtitle">A kind word, just for you.</p>
+  <div class="page-layout">
+    <div class="container">
+      <h1>Compliment Mirror</h1>
+      <p class="subtitle">A kind word, just for you.</p>
 
-    <div class="compliment-box">
-      <p class="compliment-text" id="compliment">Your compliment will appear here.</p>
+      <div class="compliment-box">
+        <p class="compliment-text" id="compliment">Your compliment will appear here.</p>
+      </div>
+
+      <p class="view-count" id="view-count"></p>
+
+      <button class="btn" id="new-compliment-btn" type="button">New Compliment</button>
+      <p class="spacebar-hint" id="spacebar-hint">Tip: press the spacebar for a new compliment.</p>
+      <input
+        type="text"
+        id="recipient-name"
+        placeholder="Add a name (optional)"
+        maxlength="60"
+        autocomplete="off"
+      />
+      <button class="btn btn-secondary" id="share-btn" type="button">Share this compliment</button>
+      <p class="share-feedback" id="share-feedback" aria-live="polite"></p>
+      <p class="visitor-counter" id="visitor-counter"></p>
     </div>
 
-    <section class="compliment-history" id="compliment-history" hidden aria-label="Recent compliments">
+    <aside class="compliment-history" id="compliment-history" hidden aria-label="Recent compliments">
       <h2 class="compliment-history-title">Recent compliments</h2>
       <ul class="compliment-history-list" id="compliment-history-list"></ul>
-    </section>
-
-    <p class="view-count" id="view-count"></p>
-
-    <button class="btn" id="new-compliment-btn" type="button">New Compliment</button>
-    <p class="spacebar-hint" id="spacebar-hint">Tip: press the spacebar for a new compliment.</p>
-    <input
-      type="text"
-      id="recipient-name"
-      placeholder="Add a name (optional)"
-      maxlength="60"
-      autocomplete="off"
-    />
-    <button class="btn btn-secondary" id="share-btn" type="button">Share this compliment</button>
-    <p class="share-feedback" id="share-feedback" aria-live="polite"></p>
-    <p class="visitor-counter" id="visitor-counter"></p>
+    </aside>
   </div>
   <canvas class="confetti-canvas" id="confetti-canvas" aria-hidden="true"></canvas>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -47,9 +47,20 @@ body {
   transition: background-color 0.3s ease, color 0.3s ease;
 }
 
+.page-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  grid-template-areas: "sidebar main";
+  gap: 2rem;
+  max-width: 900px;
+  width: 100%;
+  align-items: start;
+  padding: 1rem;
+}
+
 .container {
+  grid-area: main;
   text-align: center;
-  max-width: 560px;
   padding: 2rem;
 }
 
@@ -174,8 +185,16 @@ h1 {
 }
 
 .compliment-history {
-  margin-top: 2rem;
+  grid-area: sidebar;
   text-align: left;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1rem;
+  align-self: start;
+  position: sticky;
+  top: 1rem;
+  transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
 .compliment-history-title {
@@ -202,13 +221,39 @@ h1 {
   font-size: 0.875rem;
   font-style: italic;
   color: var(--color-subtle);
-  padding: 0.4rem 0.75rem;
+  padding: 0.4rem 0;
   border-bottom: 1px solid var(--border-color);
   transition: color 0.3s ease, border-color 0.3s ease;
 }
 
 .compliment-history-item:last-child {
   border-bottom: none;
+}
+
+.compliment-history-text {
+  display: block;
+}
+
+.compliment-history-time {
+  display: block;
+  font-size: 0.75rem;
+  font-style: normal;
+  color: var(--color-subtle);
+  opacity: 0.8;
+  margin-top: 0.125rem;
+  transition: color 0.3s ease;
+}
+
+@media (max-width: 767px) {
+  .page-layout {
+    grid-template-columns: 1fr;
+    grid-template-areas: "main" "sidebar";
+    padding: 0.5rem;
+  }
+
+  .compliment-history {
+    position: static;
+  }
 }
 
 .shared-view .container {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -2,12 +2,14 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 function createElement(tagName) {
-  return {
+  const el = {
     tagName: tagName.toUpperCase(),
     textContent: '',
     value: '',
     style: {},
     attributes: {},
+    children: [],
+    firstChild: null,
     isContentEditable: false,
     listeners: {},
     addEventListener(type, handler) {
@@ -17,13 +19,28 @@ function createElement(tagName) {
 
       this.listeners[type].push(handler);
     },
+    removeEventListener(type, handler) {
+      if (!this.listeners[type]) return;
+      this.listeners[type] = this.listeners[type].filter(h => h !== handler);
+    },
     setAttribute(name, value) {
       this.attributes[name] = value;
     },
     removeAttribute(name) {
       delete this.attributes[name];
+    },
+    appendChild(child) {
+      this.children.push(child);
+      this.firstChild = this.children[0];
+      return child;
+    },
+    removeChild(child) {
+      this.children = this.children.filter(c => c !== child);
+      this.firstChild = this.children[0] || null;
+      return child;
     }
   };
+  return el;
 }
 
 function createListElement() {
@@ -666,12 +683,17 @@ test('compliment history records picks in sessionStorage with newest first', () 
   app.renderComplimentHistory();
 
   const stored = JSON.parse(global.sessionStorage.getItem('compliment_history'));
-  assert.deepEqual(stored, [app.COMPLIMENTS[2], app.COMPLIMENTS[1], app.COMPLIMENTS[0]]);
+  assert.equal(stored.length, 3);
+  assert.equal(stored[0].text, app.COMPLIMENTS[2]);
+  assert.equal(stored[1].text, app.COMPLIMENTS[1]);
+  assert.equal(stored[2].text, app.COMPLIMENTS[0]);
+  assert.ok(typeof stored[0].timestamp === 'number');
 
   const list = document.getElementById('compliment-history-list');
   assert.equal(list.children.length, 3);
-  assert.equal(list.children[0].textContent, app.COMPLIMENTS[2]);
-  assert.equal(list.children[2].textContent, app.COMPLIMENTS[0]);
+  // Each li has a text span (children[0]) and a time span (children[1])
+  assert.equal(list.children[0].children[0].textContent, app.COMPLIMENTS[2]);
+  assert.equal(list.children[2].children[0].textContent, app.COMPLIMENTS[0]);
 
   const section = document.getElementById('compliment-history');
   assert.equal('hidden' in section.attributes, false);
@@ -694,7 +716,11 @@ test('compliment history caps at 5 entries (newest first)', () => {
 
   const stored = JSON.parse(global.sessionStorage.getItem('compliment_history'));
   assert.equal(stored.length, 5);
-  assert.deepEqual(stored, ['item-7', 'item-6', 'item-5', 'item-4', 'item-3']);
+  assert.equal(stored[0].text, 'item-7');
+  assert.equal(stored[1].text, 'item-6');
+  assert.equal(stored[2].text, 'item-5');
+  assert.equal(stored[3].text, 'item-4');
+  assert.equal(stored[4].text, 'item-3');
 
   cleanupGlobals();
 });
@@ -713,7 +739,9 @@ test('compliment history preserves consecutive duplicates in newest-first order'
   app.recordComplimentInHistory('world');
 
   const stored = JSON.parse(global.sessionStorage.getItem('compliment_history'));
-  assert.deepEqual(stored, ['world', 'hello', 'hello']);
+  assert.equal(stored[0].text, 'world');
+  assert.equal(stored[1].text, 'hello');
+  assert.equal(stored[2].text, 'hello');
 
   cleanupGlobals();
 });
@@ -852,5 +880,53 @@ test('compliment history is silently ignored when sessionStorage is unavailable'
   assert.doesNotThrow(() => global.window.domReady());
 
   Math.random = originalRandom;
+  cleanupGlobals();
+});
+
+test('formatRelativeTime returns "Just now" for timestamps within the last minute', () => {
+  const app = loadApp();
+  const now = Date.now();
+  assert.equal(app.formatRelativeTime(now), 'Just now');
+  assert.equal(app.formatRelativeTime(now - 30000), 'Just now');
+  assert.equal(app.formatRelativeTime(now - 59000), 'Just now');
+});
+
+test('formatRelativeTime returns singular and plural minutes ago', () => {
+  const app = loadApp();
+  const now = Date.now();
+  assert.equal(app.formatRelativeTime(now - 60000), '1 minute ago');
+  assert.equal(app.formatRelativeTime(now - 120000), '2 minutes ago');
+  assert.equal(app.formatRelativeTime(now - 3599000), '59 minutes ago');
+});
+
+test('formatRelativeTime returns singular and plural hours ago', () => {
+  const app = loadApp();
+  const now = Date.now();
+  assert.equal(app.formatRelativeTime(now - 3600000), '1 hour ago');
+  assert.equal(app.formatRelativeTime(now - 7200000), '2 hours ago');
+});
+
+test('compliment history renders timestamps alongside text', () => {
+  const document = createDocument();
+  global.document = document;
+  global.localStorage = createLocalStorage();
+  global.sessionStorage = createSessionStorage();
+  global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+  global.location = { href: 'https://example.com/' };
+
+  const app = loadApp();
+  app.recordComplimentInHistory('hello world');
+  app.renderComplimentHistory();
+
+  const list = document.getElementById('compliment-history-list');
+  assert.equal(list.children.length, 1);
+
+  const li = list.children[0];
+  assert.equal(li.children[0].textContent, 'hello world');
+  assert.equal(li.children[0].className, 'compliment-history-text');
+  assert.equal(li.children[1].className, 'compliment-history-time');
+  // Timestamp text should be non-empty (e.g. "Just now")
+  assert.ok(li.children[1].textContent.length > 0);
+
   cleanupGlobals();
 });


### PR DESCRIPTION
## Summary
- Moves the recent compliments section from below the main card into a dedicated left sidebar on desktop (≥768px), using CSS Grid with `grid-template-areas`
- Sidebar stacks below main content on mobile (<768px) via a responsive media query — no JavaScript required
- Adds relative timestamps (e.g. "Just now", "2 minutes ago") to each history entry, backed by a new `formatRelativeTime` helper
- History storage format updated from `string[]` to `{text, timestamp}[]` in sessionStorage; backwards-compatible parser handles any legacy string entries
- All 28 tests pass (4 new tests added for `formatRelativeTime` and timestamp rendering)

## Test plan
- [x] Run `node test/app.test.js` — all 28 tests pass
- [x] On desktop (≥768px): sidebar appears on the left with timestamps, main compliment on the right
- [x] On mobile (<768px): single column, main content first, sidebar below as full-width section
- [x] Sidebar is sticky on desktop (stays visible while scrolling long content)
- [x] Dark/light theme transitions apply to sidebar background and borders
- [x] Existing functionality (5-item cap, sessionStorage, sharing, spacebar) unchanged

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)